### PR TITLE
Fix match detail dialog crash and improve responsive match UI

### DIFF
--- a/src/components/MatchCard.tsx
+++ b/src/components/MatchCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Match, Tournament, Player, BattingScorecard, Season } from "@/lib/types";
-import { Calendar, MapPin, Award } from "lucide-react";
+import { Calendar, ChevronRight, MapPin, Award } from "lucide-react";
 import { formatSheetDate } from "@/lib/dataUtils";
 import { getTeamScoreSummary } from "@/lib/liveScoring";
 
@@ -15,6 +15,7 @@ interface MatchCardProps {
 }
 
 export function MatchCard({ match, tournament, season, players = [], batting = [], onClick }: MatchCardProps) {
+  const isInteractive = typeof onClick === "function";
   const safePlayers = players ?? [];
   const safeBatting = batting ?? [];
   const mom = safePlayers.find((p) => p.player_id === match.man_of_match);
@@ -32,13 +33,25 @@ export function MatchCard({ match, tournament, season, players = [], batting = [
 
   return (
     <Card
-      className="h-full border border-border bg-card shadow-none transition-colors duration-200 hover:border-primary/50 hover:bg-primary/[0.03] cursor-pointer active:scale-[0.98]"
+      className={`h-full border border-border bg-card shadow-none transition-all duration-200 ${isInteractive ? "cursor-pointer active:scale-[0.98] hover:-translate-y-0.5 hover:border-primary/50 hover:bg-primary/[0.03] focus-within:border-primary/60" : ""}`}
       onClick={onClick}
+      role={isInteractive ? "button" : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      onKeyDown={isInteractive ? (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick?.();
+        }
+      } : undefined}
+      aria-label={isInteractive ? `Open match details for ${match.team_a} vs ${match.team_b}` : undefined}
     >
       <CardContent className="flex h-full flex-col gap-4 p-4 sm:p-5">
-        <div className="flex items-center justify-between gap-3">
-          <span className="text-xs text-muted-foreground font-mono">{match.match_id}</span>
-          <div className="flex items-center gap-1">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <span className="block text-xs font-mono text-muted-foreground">{match.match_id}</span>
+            {isInteractive && <span className="text-[11px] font-medium text-primary">Tap for full scorecard</span>}
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-1">
             {match.match_stage && (
               <Badge variant="secondary" className="text-[10px] font-display">
                 {match.match_stage}
@@ -89,12 +102,19 @@ export function MatchCard({ match, tournament, season, players = [], batting = [
           )}
         </div>
 
-        {mom && (
-          <div className="flex items-center gap-1 mt-2 text-xs text-accent">
-            <Award className="h-3 w-3" />
-            <span className="font-medium">MOM: {mom.name}</span>
-          </div>
-        )}
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+          {mom ? (
+            <div className="flex items-center gap-1 text-xs text-accent">
+              <Award className="h-3 w-3" />
+              <span className="font-medium">MOM: {mom.name}</span>
+            </div>
+          ) : <span />}
+          {isInteractive && (
+            <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary">
+              View details <ChevronRight className="h-3 w-3" />
+            </span>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/MatchDetailDialog.tsx
+++ b/src/components/MatchDetailDialog.tsx
@@ -61,7 +61,7 @@ function buildMatchIssueTemplate(match: Match, tournament?: Tournament, season?:
   };
 }
 
-export function MatchDetailDialog({ match, open, onOpenChange, batting, bowling, players, tournament, season }: MatchDetailDialogProps) {
+export function MatchDetailDialog({ match, open, onOpenChange, batting = [], bowling = [], players = [], tournament, season }: MatchDetailDialogProps) {
   const { user } = useAuth();
   const { toast } = useToast();
   const [showReport, setShowReport] = useState(false);
@@ -97,31 +97,37 @@ export function MatchDetailDialog({ match, open, onOpenChange, batting, bowling,
   const handleReportIssue = async () => {
     if (!reportSubject.trim() || !reportDesc.trim() || !user) return;
     setSubmitting(true);
-    const sla = SLA_CONFIG[reportPriority];
-    const now = new Date();
-    const ticket: SupportTicket = {
-      ticket_id: generateId('TKT'),
-      created_by_user_id: user.player_id || user.management_id || 'admin',
-      category: reportCategory,
-      priority: reportPriority,
-      subject: `[Match: ${match.team_a} vs ${match.team_b}] ${reportSubject}`,
-      description: `${reportDesc}\n${reportDesc.includes('Issue details:') ? '' : '\nIssue details:'}\nRaised by: ${user.player_id || user.management_id || user.username}`,
-      attachment_url: '',
-      status: 'open',
-      assigned_admin_id: '',
-      created_at: istNow(),
-      first_response_due: new Date(now.getTime() + sla.firstResponse * 3600000).toISOString(),
-      resolution_due: new Date(now.getTime() + sla.resolution * 3600000).toISOString(),
-      resolved_at: '',
-      closed_at: '',
-    };
-    await v2api.addTicket(ticket);
-    logAudit(user.player_id || user.username, 'create_ticket_from_match', 'support_ticket', ticket.ticket_id, match.match_id);
-    toast({ title: '✅ Issue reported', description: 'Support ticket created for this match' });
-    setShowReport(false);
-    setReportSubject('');
-    setReportDesc('');
-    setSubmitting(false);
+    try {
+      const sla = SLA_CONFIG[reportPriority];
+      const now = new Date();
+      const ticket: SupportTicket = {
+        ticket_id: generateId('TKT'),
+        created_by_user_id: user.player_id || user.management_id || 'admin',
+        category: reportCategory,
+        priority: reportPriority,
+        subject: `[Match: ${match.team_a} vs ${match.team_b}] ${reportSubject}`,
+        description: `${reportDesc}\n${reportDesc.includes('Issue details:') ? '' : '\nIssue details:'}\nRaised by: ${user.player_id || user.management_id || user.username}`,
+        attachment_url: '',
+        status: 'open',
+        assigned_admin_id: '',
+        created_at: istNow(),
+        first_response_due: new Date(now.getTime() + sla.firstResponse * 3600000).toISOString(),
+        resolution_due: new Date(now.getTime() + sla.resolution * 3600000).toISOString(),
+        resolved_at: '',
+        closed_at: '',
+      };
+      await v2api.addTicket(ticket);
+      logAudit(user.player_id || user.username, 'create_ticket_from_match', 'support_ticket', ticket.ticket_id, match.match_id);
+      toast({ title: '✅ Issue reported', description: 'Support ticket created for this match' });
+      setShowReport(false);
+      setReportSubject('');
+      setReportDesc('');
+    } catch (error) {
+      console.error('Unable to submit match issue', error);
+      toast({ title: 'Issue not submitted', description: 'Please try again in a moment.', variant: 'destructive' });
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const renderTeamScorecard = (team: string) => {
@@ -209,7 +215,7 @@ export function MatchDetailDialog({ match, open, onOpenChange, batting, bowling,
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[92vh] flex flex-col rounded-[2rem] border-primary/10 p-4 md:p-6">
+      <DialogContent className="flex max-h-[92vh] w-[calc(100vw-1.5rem)] max-w-4xl flex-col overflow-hidden rounded-[1.5rem] border-primary/10 p-3 sm:w-full sm:rounded-[2rem] md:p-6">
         <DialogHeader>
           <DialogTitle className="font-display text-lg md:text-xl">{match.team_a} vs {match.team_b}</DialogTitle>
         </DialogHeader>
@@ -275,7 +281,7 @@ export function MatchDetailDialog({ match, open, onOpenChange, batting, bowling,
                   <Badge variant="outline" className="rounded-full">Auto-filled</Badge>
                 </div>
                 <Input value={reportSubject} onChange={e => setReportSubject(e.target.value)} placeholder="Brief summary..." />
-                <div className="flex gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row">
                   <Select value={reportCategory} onValueChange={setReportCategory}>
                     <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
                     <SelectContent>{CATEGORIES.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}</SelectContent>
@@ -290,7 +296,7 @@ export function MatchDetailDialog({ match, open, onOpenChange, batting, bowling,
                   </Select>
                 </div>
                 <Textarea value={reportDesc} onChange={e => setReportDesc(e.target.value)} placeholder="Describe the issue..." className="min-h-[180px] rounded-2xl text-sm leading-6" />
-                <div className="flex gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row">
                   <Button size="sm" onClick={handleReportIssue} disabled={submitting || !reportSubject.trim() || !reportDesc.trim()}>
                     {submitting ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null} Submit
                   </Button>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -345,7 +345,16 @@ const Home = () => {
         </section>
       </main>
 
-      <MatchDetailDialog match={selectedMatch} open={detailOpen} onOpenChange={setDetailOpen} />
+      <MatchDetailDialog
+        match={selectedMatch}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        batting={batting}
+        bowling={bowling}
+        players={players}
+        tournament={selectedMatch ? tournaments.find((tournament) => tournament.tournament_id === selectedMatch.tournament_id) : undefined}
+        season={selectedMatch ? seasons.find((season) => season.season_id === selectedMatch.season_id) : undefined}
+      />
     </div>
   );
 };

--- a/src/pages/MatchPage.tsx
+++ b/src/pages/MatchPage.tsx
@@ -130,7 +130,7 @@ const MatchPage = () => {
           <div>
             <h4 className="text-sm font-semibold mb-2 text-primary">🏏 Batting</h4>
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[640px]">
                 <TableHeader><TableRow>
                   <TableHead>Batter</TableHead><TableHead className="text-right">R</TableHead><TableHead className="text-right">B</TableHead>
                   <TableHead className="text-right">4s</TableHead><TableHead className="text-right">6s</TableHead><TableHead className="text-right">SR</TableHead><TableHead>Dismissal</TableHead>
@@ -156,7 +156,7 @@ const MatchPage = () => {
           <div>
             <h4 className="text-sm font-semibold mb-2 text-destructive">🎯 Bowling</h4>
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[520px]">
                 <TableHeader><TableRow>
                   <TableHead>Bowler</TableHead><TableHead className="text-right">O</TableHead><TableHead className="text-right">M</TableHead>
                   <TableHead className="text-right">R</TableHead><TableHead className="text-right">W</TableHead><TableHead className="text-right">Eco</TableHead>
@@ -185,7 +185,7 @@ const MatchPage = () => {
     <div className="min-h-screen bg-background">
       <Navbar />
       <div className="container mx-auto px-4 py-8 space-y-6">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button variant="ghost" size="sm" asChild><Link to="/"><ArrowLeft className="h-4 w-4" /></Link></Button>
           <h1 className="font-display text-2xl font-bold">{match.team_a} vs {match.team_b}</h1>
           <SecurityShieldBadge label="Official" variant="certified" />
@@ -201,17 +201,17 @@ const MatchPage = () => {
               <Badge className={match.status === 'live' ? 'bg-destructive text-destructive-foreground animate-pulse' : 'bg-primary text-primary-foreground'}>{match.status.toUpperCase()}</Badge>
             </div>
 
-            <div className="grid grid-cols-3 gap-4 my-4">
+            <div className="my-4 grid grid-cols-[1fr_auto_1fr] gap-2 sm:gap-4">
               <div className="text-center">
-                <p className="font-display text-xl font-bold">{match.team_a}</p>
-                <p className="text-3xl font-bold text-primary">{teamAScore?.display || '0/0 (0.0)'}</p>
+                <p className="font-display text-base font-bold sm:text-xl">{match.team_a}</p>
+                <p className="text-xl font-bold text-primary sm:text-3xl">{teamAScore?.display || '0/0 (0.0)'}</p>
               </div>
               <div className="flex items-center justify-center">
-                <span className="text-2xl font-display font-bold text-muted-foreground">VS</span>
+                <span className="text-base font-display font-bold text-muted-foreground sm:text-2xl">VS</span>
               </div>
               <div className="text-center">
-                <p className="font-display text-xl font-bold">{match.team_b}</p>
-                <p className="text-3xl font-bold text-primary">{teamBScore?.display || '0/0 (0.0)'}</p>
+                <p className="font-display text-base font-bold sm:text-xl">{match.team_b}</p>
+                <p className="text-xl font-bold text-primary sm:text-3xl">{teamBScore?.display || '0/0 (0.0)'}</p>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- Clicking a match card could open a white/blank overlay because the match detail dialog was mounted without required supporting data and crashed during render. 
- The UI needed better mobile/keyboard affordances and overflow-safe tables so scorecards and dialogs behave consistently across devices.

### Description
- Ensure `MatchDetailDialog` receives the required `batting`, `bowling`, `players`, `tournament`, and `season` props from `Home` so the dialog has the data it needs to render. 
- Harden `MatchDetailDialog` by providing safe default values for `batting`, `bowling`, and `players` and add `try/catch` around issue submission to avoid leaving the dialog stuck in a submitting state. 
- Improve `MatchCard` usability by adding keyboard support (`role`, `tabIndex`, `onKeyDown`), a tap affordance message, and a chevron icon for interactive cards so they behave correctly on mobile and desktop. 
- Adjust dialog and match page layouts for small screens and make score tables overflow horizontally (`min-w-*` on tables and width/stacking tweaks) to prevent layout breakage on mobile. 

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it completed cleanly. 
- Attempted `npm test -- --runInBand` and unit runner invocation but tests did not run because local dependencies are not installed (`vitest: not found`). 
- Attempted `npm run build` but build tooling is unavailable here (`vite: not found`). 
- Attempted `npm install` to restore dev dependencies but the environment blocked registry access (HTTP 403), so automated test/build couldn't be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5ae4d8c4832c8a7b67ad3e1e0239)