### PR TITLE
Fix scorelist stage typings and pass required props to MatchDetailDialog

### DIFF
--- a/src/lib/v2types.ts
+++ b/src/lib/v2types.ts
@@ -203,3 +203,5 @@ export const CERTIFICATION_STAGES = [
   'director_approved',
   'official_certified',
 ] as const;
+
+export type CertificationStage = (typeof CERTIFICATION_STAGES)[number];

--- a/src/lib/workflowStatus.ts
+++ b/src/lib/workflowStatus.ts
@@ -1,5 +1,5 @@
 import { scheduleApproverRoles } from '@/lib/accessControl';
-import { CertificationApproval, DigitalScorelist, ManagementUser } from '@/lib/v2types';
+import { CertificationApproval, CertificationStage, DigitalScorelist, ManagementUser } from '@/lib/v2types';
 import { ScheduleApprovalRecord, ScheduleRecord } from '@/schedules/types';
 
 export const scorelistStageOrder = ['draft', 'scoring_completed', 'referee_verified', 'director_approved', 'official_certified'] as const;
@@ -47,7 +47,7 @@ function normalizeDesignation(designation?: string) {
   return String(designation || '').trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
-export function resolveStageFromDesignation(designation?: string): (typeof scorelistStageOrder)[number] | null {
+export function resolveStageFromDesignation(designation?: string): CertificationStage | null {
   const value = normalizeDesignation(designation);
   if (!value) return null;
   if (value.includes('scoring')) return 'scoring_completed';
@@ -67,17 +67,18 @@ export function readScorelistCertifications(scorelist: DigitalScorelist): Certif
   }
 }
 
-function readScorelistStatus(scorelist: DigitalScorelist, certifications: CertificationApproval[]) {
+function readScorelistStatus(scorelist: DigitalScorelist, certifications: CertificationApproval[]): CertificationStage {
   if (scorelist.certification_status) return scorelist.certification_status;
-  return certifications.reduce<string>((current, approval) => {
-    return scorelistStageOrder.indexOf(approval.stage as (typeof scorelistStageOrder)[number]) > scorelistStageOrder.indexOf(current as (typeof scorelistStageOrder)[number])
-      ? approval.stage
+  return certifications.reduce<CertificationStage>((current, approval) => {
+    const approvalStage = approval.stage as CertificationStage;
+    return scorelistStageOrder.indexOf(approvalStage) > scorelistStageOrder.indexOf(current)
+      ? approvalStage
       : current;
   }, 'draft');
 }
 
 export interface ScorelistRoadmapStep {
-  stage: (typeof scorelistStageOrder)[number];
+  stage: CertificationStage;
   label: string;
   responsibility: string;
   completed: boolean;

--- a/src/pages/AdminScorelistsPage.tsx
+++ b/src/pages/AdminScorelistsPage.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { v2api, logAudit } from '@/lib/v2api';
-import { DigitalScorelist, CertificationApproval, ManagementUser } from '@/lib/v2types';
+import { DigitalScorelist, CertificationApproval, CertificationStage, ManagementUser } from '@/lib/v2types';
 import { getScorelistDetailedStatus, getScorelistRoadmap, readScorelistCertifications, resolveStageFromDesignation, scorelistStageLabels, scorelistStageOrder } from '@/lib/workflowStatus';
 import { verifyScorelist, exportScorelistAsJSON, generateMatchScorelist, generateTournamentScorelist } from '@/lib/scorelist';
 import { sendScorelistApprovalRequestBulk, getAdminNotificationRecipient, explainMailFailure } from '@/lib/mailer';
@@ -19,8 +19,8 @@ import { useToast } from '@/hooks/use-toast';
 import { Loader2, FileJson, ShieldCheck, ShieldX, Lock, Eye, Download, CheckCircle2, FileText } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 
-const stageLabels: Record<string, string> = scorelistStageLabels;
-const stageOrder = [...scorelistStageOrder];
+const stageLabels: Record<CertificationStage, string> = scorelistStageLabels;
+const stageOrder: CertificationStage[] = [...scorelistStageOrder];
 
 const AdminScorelistsPage = () => {
   const { isAdmin, isManagement, user } = useAuth();
@@ -110,7 +110,7 @@ const AdminScorelistsPage = () => {
     const fromPayload = payload?.__certification?.approvals;
     return Array.isArray(fromPayload) ? fromPayload : [];
   };
-  const readStatus = (sl: DigitalScorelist, certs: CertificationApproval[]): string => {
+  const readStatus = (sl: DigitalScorelist, certs: CertificationApproval[]): CertificationStage => {
     if (sl.certification_status) return sl.certification_status;
     const latest = certs.reduce((best, c) => {
       return stageOrder.indexOf(c.stage) > stageOrder.indexOf(best) ? c.stage : best;
@@ -123,12 +123,12 @@ const AdminScorelistsPage = () => {
     return !!payload?.__certification?.locked;
   };
 
-  const requiredApproversByStage = stageOrder.reduce<Record<string, ManagementUser[]>>((acc, stage) => {
+  const requiredApproversByStage = stageOrder.reduce<Record<CertificationStage, ManagementUser[]>>((acc, stage) => {
     acc[stage] = managementUsers.filter((m) => resolveStageFromDesignation(m.designation) === stage);
     return acc;
-  }, {} as Record<string, ManagementUser[]>);
+  }, {} as Record<CertificationStage, ManagementUser[]>);
 
-  const notifyStageApprovers = async (scorelistId: string, stage: string) => {
+  const notifyStageApprovers = async (scorelistId: string, stage: CertificationStage) => {
     const stageRecipients = (requiredApproversByStage[stage] || []).filter((m) => !!String(m.email || '').trim());
     const adminRecipient = getAdminNotificationRecipient();
     const recipients = [...stageRecipients];
@@ -379,8 +379,8 @@ ${effectiveLocked ? '<div class="certified">✔ OFFICIALLY CERTIFIED MATCH RESUL
   // Determine which certification stage this management user can approve
   const userStage = isManagement && user?.designation ? resolveStageFromDesignation(user.designation) : null;
 
-  const getNextStage = (sl: DigitalScorelist): string | null => {
-    const current = sl.certification_status || 'draft';
+  const getNextStage = (sl: DigitalScorelist): CertificationStage | null => {
+    const current = (sl.certification_status as CertificationStage) || 'draft';
     const idx = stageOrder.indexOf(current);
     if (idx < stageOrder.length - 1) return stageOrder[idx + 1];
     return null;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -365,7 +365,16 @@ const Home = () => {
         </section>
       </main>
 
-      <MatchDetailDialog match={selectedMatch} open={detailOpen} onOpenChange={setDetailOpen} />
+      <MatchDetailDialog
+        match={selectedMatch}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        batting={batting}
+        bowling={bowling}
+        players={players}
+        tournament={selectedMatch ? tournaments.find((t) => t.tournament_id === selectedMatch.tournament_id) : undefined}
+        season={selectedMatch ? seasons.find((s) => s.season_id === selectedMatch.season_id) : undefined}
+      />
     </div>
   );
 };

--- a/src/pages/ManagementPage.tsx
+++ b/src/pages/ManagementPage.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { User, Shield, ShieldCheck, Clock, CheckCircle2, ChevronDown, ChevronUp, Send, Loader2, MessageSquare, Crown, Star, FileText, Users, AlertTriangle } from 'lucide-react';
 import { format } from 'date-fns';
 import { v2api, logAudit, istNow } from '@/lib/v2api';
-import { ManagementUser, DigitalScorelist, CertificationApproval } from '@/lib/v2types';
+import { ManagementUser, DigitalScorelist, CertificationApproval, CertificationStage } from '@/lib/v2types';
 import { getScorelistDetailedStatus, getScorelistRoadmap, resolveStageFromDesignation, scorelistStageLabels, scorelistStageOrder } from '@/lib/workflowStatus';
 import { useToast } from '@/hooks/use-toast';
 import { Navigate, Link } from 'react-router-dom';
@@ -23,8 +23,8 @@ import { getAdminNotificationRecipient, sendScorelistApprovalRequestBulk, sendSy
 import { DataIntegrityBadge, SecurityShieldBadge, SessionFingerprint } from '@/components/SecurityBadge';
 import { PageLoader } from '@/components/LoadingOverlay';
 
-const stageOrder = [...scorelistStageOrder];
-const stageLabels: Record<string, string> = scorelistStageLabels;
+const stageOrder: CertificationStage[] = [...scorelistStageOrder];
+const stageLabels: Record<CertificationStage, string> = scorelistStageLabels;
 
 const ManagementPage = () => {
   const { user, isManagement, isAdmin } = useAuth();
@@ -72,7 +72,7 @@ const ManagementPage = () => {
     const userStage = resolveStageFromDesignation(user.designation || '');
     if (!userStage) return false;
     if (userStage === 'official_certified' && certs.some(c => c.stage === 'official_certified')) return false;
-    const currentIdx = stageOrder.indexOf(s.certification_status || 'draft');
+    const currentIdx = stageOrder.indexOf((s.certification_status as CertificationStage) || 'draft');
     const nextStage = currentIdx < stageOrder.length - 1 ? stageOrder[currentIdx + 1] : null;
     return nextStage === userStage;
   }), [isManagement, scorelists, user?.designation, user?.management_id]);


### PR DESCRIPTION
### Motivation
- Resolve TypeScript errors caused by treating certification stages as plain `string` values instead of the known literal union, and fix a missing-props error when rendering the match detail dialog on the home page.

### Description
- Add a shared `CertificationStage` type in `src/lib/v2types.ts` derived from `CERTIFICATION_STAGES` so stages are a typed union (`CertificationStage`).
- Update `src/lib/workflowStatus.ts` to use `CertificationStage` for `resolveStageFromDesignation`, `readScorelistStatus`, and `ScorelistRoadmapStep` to make stage comparisons type-safe.
- Update `src/pages/AdminScorelistsPage.tsx` to use `CertificationStage` for `stageOrder`, `stageLabels`, `readStatus`, `requiredApproversByStage`, `notifyStageApprovers`, and `getNextStage` so `indexOf` and notification calls accept the correct typed values.
- Update `src/pages/ManagementPage.tsx` to use `CertificationStage` for `stageOrder`/`stageLabels` and to cast stored `certification_status` values when computing the next stage.
- Fix `src/pages/Home.tsx` to pass the required `batting`, `bowling`, `players`, `tournament`, and `season` props into `MatchDetailDialog` so its props match `MatchDetailDialogProps`.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript compilation check succeeded.
- Attempted `npm run build` but it failed in this environment because project dependencies (including `vite`) are not installed and are unavailable here.
- Attempted `npm test` but it failed in this environment because test runner dependencies (including `vitest`) are not installed and are unavailable here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd68e6f6d4832cafa617874a400029)