### PR TITLE
Redesign UI: centered medium layout with green/white/red theme

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,13 +10,13 @@ export function Navbar() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
-  const navBtnClass = 'justify-start rounded-full px-3.5 text-foreground/80 hover:bg-primary/10 hover:text-primary';
+  const navBtnClass = 'justify-center rounded-full px-4 text-foreground/80 hover:bg-primary/8 hover:text-primary';
 
   const NavItems = ({ mobile = false }: { mobile?: boolean }) => {
     const close = () => mobile && setOpen(false);
 
     return (
-      <div className={mobile ? 'flex flex-col gap-1.5' : 'flex flex-wrap items-center gap-1'}>
+      <div className={mobile ? 'flex flex-col gap-2 text-center' : 'flex flex-wrap items-center justify-center gap-2'}>
         <Button variant="ghost" size="sm" className={navBtnClass} asChild onClick={close}>
           <Link to="/"><Home className="h-4 w-4" /> Home</Link>
         </Button>
@@ -45,7 +45,7 @@ export function Navbar() {
         )}
 
         {!user && (
-          <Button size="sm" className="rounded-full px-4" asChild onClick={close}>
+          <Button size="sm" className="px-5" asChild onClick={close}>
             <Link to="/login"><LogIn className="h-4 w-4" /> Login</Link>
           </Button>
         )}
@@ -88,14 +88,14 @@ export function Navbar() {
         )}
 
         {user && (
-          <div className={`flex items-center gap-2 ${mobile ? 'mt-3 border-t border-border/50 pt-3' : 'ml-1 border-l border-border/50 pl-2'}`}>
-            <div className="rounded-full border border-primary/15 bg-primary/8 px-3 py-1 text-xs text-muted-foreground">
+          <div className={`flex items-center gap-2 ${mobile ? 'mt-4 justify-center border-t border-primary/10 pt-4' : 'justify-center border-t border-primary/10 pt-3 lg:ml-2 lg:border-l lg:border-t-0 lg:pl-3 lg:pt-0'}`}>
+            <div className="rounded-full border border-primary/15 bg-primary/5 px-3 py-1.5 text-sm text-muted-foreground">
               Hi, <strong className="text-foreground">{user.name}</strong>
             </div>
             <Button
               variant="ghost"
               size="icon"
-              className="rounded-full text-foreground/70 hover:bg-destructive/10 hover:text-destructive"
+              className="text-foreground/70 hover:bg-destructive/10 hover:text-destructive"
               onClick={() => {
                 logout();
                 navigate('/');
@@ -111,30 +111,30 @@ export function Navbar() {
   };
 
   return (
-    <nav className="sticky top-0 z-40 border-b border-border/50 bg-card/85 backdrop-blur-xl">
-      <div className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
+    <nav className="sticky top-0 z-40 border-b border-primary/10 bg-white/90 backdrop-blur-xl">
+      <div className="mx-auto flex min-h-[5rem] w-full max-w-5xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
         <Link to="/" className="flex min-w-0 items-center gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-md">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[1.1rem] bg-primary text-primary-foreground shadow-[0_14px_30px_-18px_rgba(22,101,52,0.55)]">
             🏏
           </div>
           <div className="min-w-0">
-            <p className="truncate font-display text-base font-semibold tracking-tight text-foreground">Stumps Stats Sphere</p>
-            <p className="truncate text-[10px] uppercase tracking-widest text-muted-foreground">Cricket portal</p>
+            <p className="truncate font-display text-lg font-semibold tracking-tight text-foreground">Stumps Stats Sphere</p>
+            <p className="truncate text-[11px] uppercase tracking-[0.25em] text-muted-foreground">Centered cricket portal</p>
           </div>
         </Link>
 
-        <div className="hidden lg:flex items-center gap-1 rounded-full border border-border/50 bg-card/70 px-2 py-1.5 shadow-sm backdrop-blur-xl">
+        <div className="hidden lg:flex max-w-[65%] items-center justify-center rounded-full border border-primary/10 bg-white px-3 py-2 shadow-sm">
           <NavItems />
         </div>
 
         <div className="lg:hidden">
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>
-              <Button variant="outline" size="icon" className="rounded-full">
+              <Button variant="outline" size="icon">
                 <Menu className="h-5 w-5" />
               </Button>
             </SheetTrigger>
-            <SheetContent side="right" className="w-[88vw] max-w-sm border-border/50 bg-background/95 pt-10 backdrop-blur-xl">
+            <SheetContent side="right" className="w-[90vw] max-w-sm border-primary/10 bg-white/95 pt-12 backdrop-blur-xl">
               <NavItems mobile />
             </SheetContent>
           </Sheet>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,22 +5,22 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:-translate-y-0.5 active:translate-y-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-[0.95rem] font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:-translate-y-0.5 active:translate-y-0",
   {
     variants: {
       variant: {
-        default: "border border-primary/30 bg-primary text-primary-foreground shadow-md hover:brightness-110",
-        destructive: "border border-destructive/30 bg-destructive text-destructive-foreground shadow-md hover:brightness-110",
-        outline: "border border-border bg-card/80 text-foreground shadow-sm hover:bg-primary/8 hover:text-primary hover:border-primary/30",
-        secondary: "border border-secondary/40 bg-secondary/20 text-secondary-foreground shadow-sm hover:bg-secondary/30",
-        ghost: "bg-transparent text-foreground hover:bg-primary/10 hover:text-primary shadow-none",
+        default: "border border-primary/30 bg-primary text-primary-foreground shadow-[0_16px_30px_-20px_rgba(22,101,52,0.6)] hover:brightness-110",
+        destructive: "border border-destructive/30 bg-destructive text-destructive-foreground shadow-[0_16px_30px_-20px_rgba(220,38,38,0.55)] hover:brightness-110",
+        outline: "border border-primary/15 bg-white text-foreground shadow-sm hover:bg-primary/5 hover:text-primary hover:border-primary/30",
+        secondary: "border border-border bg-secondary text-secondary-foreground shadow-sm hover:bg-muted",
+        ghost: "bg-transparent text-foreground hover:bg-primary/8 hover:text-primary shadow-none",
         link: "text-primary underline-offset-4 shadow-none hover:underline",
       },
       size: {
-        default: "h-10 px-5 py-2",
-        sm: "h-8 px-3.5 text-xs",
-        lg: "h-11 px-6 text-sm",
-        icon: "h-9 w-9 rounded-xl",
+        default: "h-11 px-5 py-2.5",
+        sm: "h-9 px-4 text-sm",
+        lg: "h-12 px-6 text-base",
+        icon: "h-10 w-10 rounded-2xl",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-border/50 bg-card/90 text-card-foreground shadow-md backdrop-blur-xl",
+      "rounded-[1.35rem] border border-primary/10 bg-white/95 text-card-foreground shadow-[0_22px_50px_-36px_rgba(22,101,52,0.22)] backdrop-blur-xl",
       className,
     )}
     {...props}
@@ -15,14 +15,14 @@ Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-5", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col space-y-2 p-6", className)} {...props} />
   ),
 );
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("text-xl font-semibold leading-none tracking-tight", className)} {...props} />
+    <h3 ref={ref} className={cn("text-[1.35rem] font-semibold leading-none tracking-tight", className)} {...props} />
   ),
 );
 CardTitle.displayName = "CardTitle";
@@ -35,13 +35,13 @@ const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttribu
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />,
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />,
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-5 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
   ),
 );
 CardFooter.displayName = "CardFooter";

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-xl border border-white/80 bg-white/88 px-3.5 py-2 text-sm shadow-[0_10px_26px_-22px_rgba(15,23,42,0.22)] ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-[1rem] border border-primary/15 bg-white px-4 py-2.5 text-[0.95rem] shadow-[0_12px_30px_-24px_rgba(22,101,52,0.22)] ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/src/index.css
+++ b/src/index.css
@@ -6,69 +6,69 @@
 
 @layer base {
   :root {
-    --background: 140 20% 97%;
-    --foreground: 152 30% 15%;
+    --background: 0 0% 100%;
+    --foreground: 138 42% 16%;
     --card: 0 0% 100%;
-    --card-foreground: 152 30% 15%;
+    --card-foreground: 138 42% 16%;
     --popover: 0 0% 100%;
-    --popover-foreground: 152 30% 15%;
-    --primary: 152 60% 32%;
+    --popover-foreground: 138 42% 16%;
+    --primary: 138 56% 32%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 42 90% 55%;
-    --secondary-foreground: 152 30% 15%;
-    --muted: 140 14% 93%;
-    --muted-foreground: 150 10% 42%;
-    --accent: 42 90% 55%;
-    --accent-foreground: 152 30% 15%;
-    --destructive: 0 72% 51%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 138 42% 16%;
+    --muted: 120 14% 95%;
+    --muted-foreground: 138 18% 38%;
+    --accent: 120 20% 94%;
+    --accent-foreground: 138 42% 18%;
+    --destructive: 0 72% 46%;
     --destructive-foreground: 0 0% 100%;
-    --border: 140 18% 84%;
-    --input: 140 16% 88%;
-    --ring: 152 60% 32%;
-    --radius: 0.85rem;
-    --cricket-green: 152 60% 32%;
-    --cricket-dark: 152 40% 22%;
-    --cricket-gold: 42 90% 55%;
-    --cricket-red: 0 72% 51%;
-    --cricket-blue: 198 70% 50%;
-    --sidebar-background: 152 40% 14%;
-    --sidebar-foreground: 140 20% 97%;
-    --sidebar-primary: 42 90% 55%;
-    --sidebar-primary-foreground: 152 40% 14%;
-    --sidebar-accent: 152 32% 22%;
-    --sidebar-accent-foreground: 140 20% 97%;
-    --sidebar-border: 152 28% 28%;
-    --sidebar-ring: 42 90% 55%;
+    --border: 138 22% 84%;
+    --input: 120 14% 93%;
+    --ring: 138 56% 32%;
+    --radius: 1rem;
+    --cricket-green: 138 56% 32%;
+    --cricket-dark: 138 44% 18%;
+    --cricket-gold: 0 0% 100%;
+    --cricket-red: 0 72% 46%;
+    --cricket-blue: 0 0% 100%;
+    --sidebar-background: 0 0% 100%;
+    --sidebar-foreground: 138 42% 16%;
+    --sidebar-primary: 138 56% 32%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 120 20% 94%;
+    --sidebar-accent-foreground: 138 42% 16%;
+    --sidebar-border: 138 22% 84%;
+    --sidebar-ring: 138 56% 32%;
   }
 
   .dark {
-    --background: 152 25% 8%;
-    --foreground: 140 20% 95%;
-    --card: 152 25% 12%;
-    --card-foreground: 140 20% 95%;
-    --popover: 152 25% 12%;
-    --popover-foreground: 140 20% 95%;
-    --primary: 152 55% 42%;
-    --primary-foreground: 152 25% 8%;
-    --secondary: 42 80% 50%;
-    --secondary-foreground: 140 20% 95%;
-    --muted: 152 20% 16%;
-    --muted-foreground: 140 12% 65%;
-    --accent: 42 80% 50%;
-    --accent-foreground: 152 25% 8%;
-    --destructive: 0 72% 51%;
-    --destructive-foreground: 140 20% 95%;
-    --border: 152 16% 24%;
-    --input: 152 16% 24%;
-    --ring: 42 80% 50%;
-    --sidebar-background: 152 30% 6%;
-    --sidebar-foreground: 140 20% 95%;
-    --sidebar-primary: 42 80% 55%;
-    --sidebar-primary-foreground: 152 30% 6%;
-    --sidebar-accent: 152 20% 16%;
-    --sidebar-accent-foreground: 140 20% 95%;
-    --sidebar-border: 152 16% 20%;
-    --sidebar-ring: 42 80% 50%;
+    --background: 138 24% 10%;
+    --foreground: 0 0% 98%;
+    --card: 138 22% 13%;
+    --card-foreground: 0 0% 98%;
+    --popover: 138 22% 13%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 138 48% 48%;
+    --primary-foreground: 138 28% 10%;
+    --secondary: 138 14% 18%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 138 14% 18%;
+    --muted-foreground: 120 8% 72%;
+    --accent: 138 18% 20%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 65% 52%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 138 16% 24%;
+    --input: 138 16% 24%;
+    --ring: 138 48% 48%;
+    --sidebar-background: 138 24% 10%;
+    --sidebar-foreground: 0 0% 98%;
+    --sidebar-primary: 138 48% 48%;
+    --sidebar-primary-foreground: 138 28% 10%;
+    --sidebar-accent: 138 18% 20%;
+    --sidebar-accent-foreground: 0 0% 98%;
+    --sidebar-border: 138 16% 24%;
+    --sidebar-ring: 138 48% 48%;
   }
 }
 
@@ -80,11 +80,11 @@
     scroll-behavior: smooth;
   }
   body {
-    @apply min-h-screen bg-background text-foreground font-body;
+    @apply min-h-screen bg-background text-foreground font-body antialiased;
+    font-size: 15.5px;
     background-image:
-      radial-gradient(circle at top left, hsla(152, 60%, 32%, 0.06), transparent 40%),
-      radial-gradient(circle at bottom right, hsla(42, 90%, 55%, 0.05), transparent 40%),
-      linear-gradient(180deg, hsl(140 20% 97%), hsl(140 18% 95%));
+      radial-gradient(circle at top, hsla(138, 56%, 32%, 0.08), transparent 38%),
+      linear-gradient(180deg, #ffffff 0%, #f9fcf9 52%, #f2f7f3 100%);
     background-attachment: fixed;
   }
   h1, h2, h3, h4, h5, h6 {
@@ -94,7 +94,7 @@
     min-height: 100vh;
   }
   ::selection {
-    background: hsla(152, 60%, 32%, 0.18);
+    background: hsla(138, 56%, 32%, 0.18);
     color: hsl(var(--foreground));
   }
 }
@@ -107,6 +107,10 @@
     font-family: 'Inter', sans-serif;
   }
 
+  .container {
+    max-width: 74rem !important;
+  }
+
   .scrollbar-thin {
     scrollbar-width: thin;
     scrollbar-color: hsl(var(--border)) transparent;
@@ -115,120 +119,118 @@
   .scrollbar-thin::-webkit-scrollbar-track { background: transparent; }
   .scrollbar-thin::-webkit-scrollbar-thumb { background-color: hsl(var(--border)); border-radius: 3px; }
 
-  /* Glass panels */
   .glass-panel {
-    @apply border border-border/50 bg-card/80 shadow-lg backdrop-blur-xl;
+    @apply border border-primary/10 bg-white/92 shadow-[0_24px_60px_-34px_rgba(22,101,52,0.28)] backdrop-blur-md;
   }
   .glass-card {
-    @apply rounded-2xl border border-border/50 bg-card/80 shadow-md backdrop-blur-xl;
+    @apply rounded-[1.35rem] border border-primary/10 bg-white/95 shadow-[0_22px_50px_-36px_rgba(22,101,52,0.24)] backdrop-blur;
   }
 
-  /* Page shells */
   .page-shell {
-    @apply relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 shadow-xl backdrop-blur-xl;
+    @apply relative mx-auto w-full max-w-5xl overflow-hidden rounded-[1.6rem] border border-primary/10 bg-white/92 shadow-[0_30px_80px_-40px_rgba(22,101,52,0.22)] backdrop-blur-xl;
   }
   .admin-section-shell {
-    @apply rounded-2xl border border-primary/15 bg-gradient-to-br from-card via-card to-primary/5 shadow-lg;
+    @apply rounded-[1.4rem] border border-primary/10 bg-gradient-to-br from-white via-white to-primary/5 shadow-[0_24px_60px_-40px_rgba(22,101,52,0.24)];
   }
 
-  /* Portal components */
   .portal-hero {
-    @apply rounded-2xl border border-border/50 bg-gradient-to-br from-card/95 to-card/85 p-5 shadow-lg backdrop-blur-xl sm:p-6;
+    @apply mx-auto flex w-full max-w-5xl flex-col items-center rounded-[1.8rem] border border-primary/10 bg-white/95 p-6 text-center shadow-[0_28px_70px_-40px_rgba(22,101,52,0.28)] backdrop-blur-xl sm:p-8;
   }
   .portal-panel {
-    @apply rounded-xl border border-border/50 bg-card/80 shadow-md backdrop-blur-xl;
+    @apply mx-auto w-full rounded-[1.35rem] border border-primary/10 bg-white/95 shadow-[0_20px_50px_-36px_rgba(22,101,52,0.22)] backdrop-blur-xl;
   }
   .portal-pill {
-    @apply w-fit rounded-full border border-primary/15 bg-primary/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-primary;
+    @apply w-fit rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary;
   }
   .portal-label {
-    @apply text-[10px] font-semibold uppercase tracking-widest text-muted-foreground;
+    @apply text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground;
   }
   .portal-stat-card {
-    @apply rounded-xl border border-border/50 bg-card/80 p-3.5 shadow-sm;
+    @apply rounded-[1.2rem] border border-primary/10 bg-gradient-to-b from-white to-primary/5 p-4 shadow-sm;
   }
   .portal-mini-card {
-    @apply flex flex-col rounded-xl border border-border/40 bg-gradient-to-b from-muted/40 to-card/80 p-3.5;
+    @apply flex flex-col rounded-[1.15rem] border border-primary/10 bg-gradient-to-b from-white to-muted/50 p-4;
   }
   .portal-input {
-    @apply rounded-xl border-border/60 bg-card/90 shadow-sm;
+    @apply rounded-[1rem] border-primary/15 bg-white shadow-sm;
   }
 
-  /* Typography */
   .section-heading {
-    @apply font-display text-2xl font-bold tracking-tight text-foreground;
+    @apply font-display text-[1.85rem] font-semibold tracking-tight text-foreground;
   }
   .eyebrow {
-    @apply mb-2 text-[11px] font-semibold uppercase tracking-widest text-primary/70;
+    @apply mb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary/70;
   }
 
-  /* Metric tiles */
   .metric-tile {
-    @apply rounded-xl border border-primary/10 bg-gradient-to-br from-card to-primary/5 p-4 shadow-md transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-lg;
+    @apply rounded-[1.2rem] border border-primary/10 bg-gradient-to-br from-white to-primary/5 p-4 shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md;
   }
 
-  /* Hero components */
   .hero-panel {
-    @apply relative overflow-hidden rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/90 via-primary to-primary/80 shadow-2xl;
+    @apply relative overflow-hidden rounded-[1.8rem] border border-primary/15 bg-gradient-to-br from-primary via-primary to-primary/90 shadow-[0_30px_80px_-42px_rgba(22,101,52,0.6)];
   }
   .hero-panel::before {
     content: "";
     position: absolute;
     inset: 0;
-    background: linear-gradient(125deg, rgba(255,255,255,0.1), transparent 50%);
+    background: linear-gradient(145deg, rgba(255,255,255,0.18), transparent 50%);
     pointer-events: none;
   }
   .hero-gradient {
-    background-image: linear-gradient(135deg, hsla(152, 60%, 32%, 0.08), hsla(42, 90%, 55%, 0.1), hsla(152, 60%, 32%, 0.06));
+    background-image: linear-gradient(135deg, hsla(138, 56%, 32%, 0.06), hsla(0, 0%, 100%, 0.85), hsla(0, 72%, 46%, 0.05));
   }
   .hero-grid {
-    background-image: linear-gradient(hsla(152, 60%, 32%, 0.06) 1px, transparent 1px), linear-gradient(90deg, hsla(42, 90%, 55%, 0.06) 1px, transparent 1px);
-    background-size: 40px 40px;
-    mask-image: linear-gradient(to bottom, rgba(0,0,0,0.8), transparent 75%);
+    background-image: linear-gradient(hsla(138, 56%, 32%, 0.05) 1px, transparent 1px), linear-gradient(90deg, hsla(0, 72%, 46%, 0.05) 1px, transparent 1px);
+    background-size: 32px 32px;
+    mask-image: linear-gradient(to bottom, rgba(0,0,0,0.75), transparent 78%);
   }
   .hero-orb {
-    position: absolute; border-radius: 9999px; filter: blur(28px); opacity: 0.5;
+    position: absolute; border-radius: 9999px; filter: blur(28px); opacity: 0.4;
     animation: float 10s ease-in-out infinite; pointer-events: none;
   }
-  .hero-orb-cyan { top: 4rem; right: 8%; height: 14rem; width: 14rem; background: hsla(152, 60%, 50%, 0.15); }
-  .hero-orb-violet { top: 2rem; left: 8%; height: 18rem; width: 18rem; background: hsla(42, 90%, 55%, 0.12); animation-delay: -2s; }
-  .hero-orb-gold { bottom: 0; left: 35%; height: 12rem; width: 12rem; background: hsla(42, 90%, 60%, 0.14); animation-delay: -4s; }
+  .hero-orb-cyan { top: 4rem; right: 8%; height: 14rem; width: 14rem; background: hsla(138, 56%, 40%, 0.16); }
+  .hero-orb-violet { top: 2rem; left: 8%; height: 18rem; width: 18rem; background: hsla(0, 0%, 100%, 0.4); animation-delay: -2s; }
+  .hero-orb-gold { bottom: 0; left: 35%; height: 12rem; width: 12rem; background: hsla(0, 72%, 46%, 0.12); animation-delay: -4s; }
   .hero-badge {
-    @apply w-fit rounded-full border border-primary-foreground/20 bg-primary-foreground/10 px-4 py-2 text-sm text-primary-foreground/90 backdrop-blur-xl;
+    @apply w-fit rounded-full border border-white/25 bg-white/12 px-4 py-2 text-sm text-white/90 backdrop-blur-xl;
   }
   .hero-stat-card {
-    @apply rounded-xl border border-primary-foreground/15 bg-primary-foreground/10 px-4 py-4 backdrop-blur-xl;
+    @apply rounded-[1.1rem] border border-white/20 bg-white/12 px-4 py-4 backdrop-blur-xl;
   }
   .hero-visual {
-    box-shadow: 0 30px 70px -40px hsla(152, 60%, 32%, 0.4);
+    box-shadow: 0 30px 70px -40px hsla(138, 56%, 32%, 0.45);
   }
 
-  /* Feature chips */
   .feature-chip {
-    @apply flex items-start gap-3 rounded-xl border border-primary-foreground/15 bg-primary-foreground/10 p-4 backdrop-blur-xl;
+    @apply flex items-start gap-3 rounded-[1.1rem] border border-primary/10 bg-white/90 p-4 backdrop-blur-xl;
   }
   .feature-chip-icon {
-    @apply inline-flex h-10 w-10 items-center justify-center rounded-xl border border-primary-foreground/15;
+    @apply inline-flex h-10 w-10 items-center justify-center rounded-[0.95rem] border border-primary/10;
   }
 
-  /* Inputs */
   .neo-input {
-    @apply border-border/60 bg-card/80 shadow-sm backdrop-blur-xl;
+    @apply border-primary/15 bg-white shadow-sm backdrop-blur-xl;
   }
 
-  /* Soft patterns */
   .soft-dot-grid {
-    background-image: radial-gradient(circle at 1px 1px, hsl(var(--primary) / 0.1) 1px, transparent 0);
+    background-image: radial-gradient(circle at 1px 1px, hsl(var(--primary) / 0.08) 1px, transparent 0);
     background-size: 20px 20px;
+  }
+
+  .center-page {
+    @apply mx-auto flex w-full max-w-5xl flex-col items-center gap-6 px-4 py-6 text-center sm:px-6;
+  }
+
+  .center-stack {
+    @apply mx-auto flex w-full max-w-4xl flex-col items-center gap-4 text-center;
   }
 }
 
-/* Interactions */
 button, [role="button"], a[class*="btn"] {
   transition: transform 0.12s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 button:active, [role="button"]:active {
-  transform: scale(0.97);
+  transform: scale(0.98);
 }
 
 @keyframes ticker {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -25,15 +25,15 @@ const AdminDashboard = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
-      <div className="container mx-auto px-4 py-6">
-        <div className="mb-6 rounded-3xl border border-primary/20 bg-gradient-to-r from-primary/10 via-background to-accent/10 p-6">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
+      <div className="center-page items-stretch text-left">
+        <div className="page-shell mb-2 p-6 sm:p-8">
+          <div className="flex flex-col items-center gap-5 text-center md:text-center">
+            <div className="center-stack">
               <p className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Operations command center</p>
               <h1 className="font-display text-3xl font-bold">⚙️ Admin Dashboard</h1>
               <p className="mt-1 text-sm text-muted-foreground">Manage tournaments, communication, support, scorelists, live scoring, and security auditing from one place.</p>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap justify-center gap-3">
               <Button asChild variant="outline" size="sm">
                 <Link to="/admin/match-center"><Zap className="h-4 w-4 mr-1" /> Open Live Scoring Panel</Link>
               </Button>
@@ -45,7 +45,7 @@ const AdminDashboard = () => {
         </div>
 
         <Tabs defaultValue="matches" className="w-full">
-          <TabsList className="flex flex-wrap h-auto gap-1 mb-6">
+          <TabsList className="mb-6 flex h-auto w-full flex-wrap justify-center gap-2 rounded-[1.3rem] border border-primary/10 bg-white p-2">
             <TabsTrigger value="matches" className="flex items-center gap-1 text-xs">
               <Gamepad2 className="h-3 w-3" /> Matches & Scorecards
             </TabsTrigger>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -86,12 +86,12 @@ const Home = () => {
       <Navbar />
       <AnnouncementTicker />
 
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 sm:px-6 lg:px-8 lg:py-6">
+      <main className="center-page items-stretch gap-6">
         {/* Hero */}
         <section className="portal-hero overflow-hidden">
-          <div className="grid gap-5 lg:grid-cols-[1.15fr_0.85fr]">
-            <div className="space-y-5">
-              <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-col items-center gap-6">
+            <div className="center-stack max-w-4xl space-y-5">
+              <div className="flex flex-wrap items-center justify-center gap-2">
                 <Badge className="portal-pill">🏏 Cricket Hub</Badge>
                 <Badge variant="outline" className="rounded-full border-primary/15 bg-primary/5 px-3 py-1 text-[11px] uppercase tracking-widest text-muted-foreground">
                   Stats · Scores · Standings
@@ -99,15 +99,15 @@ const Home = () => {
               </div>
 
               <div className="space-y-3">
-                <h1 className="max-w-3xl font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-5xl lg:leading-tight">
+                <h1 className="max-w-3xl font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-[3.2rem] lg:leading-[1.1]">
                   Your complete cricket analytics portal.
                 </h1>
-                <p className="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+                <p className="max-w-2xl text-base leading-7 text-muted-foreground">
                   Track matches, explore leaderboards, follow live scores, and dive into season-by-season tournament data — all in one place.
                 </p>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="grid w-full gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 {heroStats.map(({ label, value, icon: Icon }) => (
                   <div key={label} className="portal-stat-card">
                     <div className="flex items-center justify-between">
@@ -121,7 +121,7 @@ const Home = () => {
                 ))}
               </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row">
+              <div className="flex flex-col justify-center gap-3 sm:flex-row">
                 <Button className="sm:min-w-[170px]" asChild>
                   <Link to="/leaderboards">Explore leaderboards</Link>
                 </Button>
@@ -132,7 +132,7 @@ const Home = () => {
             </div>
 
             {/* Snapshot card */}
-            <Card className="portal-panel">
+            <Card className="portal-panel max-w-3xl">
               <CardContent className="space-y-4 p-5">
                 <div className="flex items-start justify-between gap-4">
                   <div>
@@ -177,7 +177,7 @@ const Home = () => {
         )}
 
         {/* Filters + Seasons */}
-        <section className="grid gap-5 xl:grid-cols-[0.95fr_1.05fr]">
+        <section className="mx-auto grid w-full max-w-5xl gap-5">
           <Card className="portal-panel shadow-none">
             <CardContent className="p-5">
               <div className="mb-4">
@@ -208,7 +208,7 @@ const Home = () => {
 
           <Card className="portal-panel shadow-none">
             <CardContent className="p-5">
-              <div className="mb-4 flex items-center justify-between gap-3">
+              <div className="mb-4 flex flex-wrap items-center justify-center gap-3 text-center">
                 <div>
                   <p className="portal-label">📋 Seasons Overview</p>
                   <h2 className="font-display text-xl font-semibold tracking-tight">Current campaigns</h2>
@@ -324,7 +324,7 @@ const Home = () => {
           <div className="space-y-5">
             <Card className="portal-panel shadow-none">
               <CardContent className="p-5">
-                <div className="mb-4 flex items-center justify-between gap-3">
+                <div className="mb-4 flex flex-wrap items-center justify-center gap-3 text-center">
                   <div>
                     <p className="portal-label">Leaderboards</p>
                     <h2 className="font-display text-xl font-semibold tracking-tight">Top performers</h2>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -53,11 +53,11 @@ const Login = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
-      <div className="flex items-center justify-center py-16 px-4">
-        <Card className="w-full max-w-md shadow-lg">
-          <CardHeader className="text-center pb-2">
-            <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary text-primary-foreground text-2xl shadow-md">🏏</div>
-            <CardTitle className="font-display text-2xl">Welcome Back</CardTitle>
+      <div className="center-page min-h-[calc(100vh-5rem)] justify-center">
+        <Card className="w-full max-w-lg text-center">
+          <CardHeader className="text-center pb-3">
+            <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-[1.35rem] bg-primary text-3xl text-primary-foreground shadow-[0_18px_34px_-18px_rgba(22,101,52,0.55)]">🏏</div>
+            <CardTitle className="font-display text-3xl">Welcome Back</CardTitle>
             <CardDescription>Sign in to your cricket portal account</CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/pages/PlayerDashboard.tsx
+++ b/src/pages/PlayerDashboard.tsx
@@ -108,16 +108,16 @@ const PlayerDashboard = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
-      <div className="container mx-auto px-4 py-6 space-y-6">
+      <div className="center-page items-stretch space-y-0 text-left">
         {loading && <p className="rounded-lg border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">Refreshing player dashboard data, please wait...</p>}
         {/* Enhanced Player Hero Card */}
-        <Card className="border-2 border-primary/20 bg-gradient-to-br from-primary/5 via-accent/5 to-transparent overflow-hidden">
+        <Card className="page-shell overflow-hidden border-primary/15 bg-gradient-to-br from-white via-white to-primary/5">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row items-start md:items-center gap-4">
+            <div className="flex flex-col items-center gap-5 text-center md:text-center">
               <div className="h-20 w-20 rounded-2xl bg-gradient-to-br from-primary to-accent flex items-center justify-center shrink-0">
                 <User className="h-10 w-10 text-primary-foreground" />
               </div>
-              <div className="flex-1">
+              <div className="center-stack flex-1">
                 <div className="flex items-center gap-2 mb-1">
                   <h1 className="font-display text-2xl md:text-3xl font-bold">{player.name}</h1>
                   <SecurityShieldBadge label="Verified" />
@@ -127,7 +127,7 @@ const PlayerDashboard = () => {
                 <SessionFingerprint />
               </div>
               {/* Quick Stats */}
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid w-full max-w-xl grid-cols-1 gap-3 sm:grid-cols-3">
                 <div className="text-center p-3 rounded-xl bg-primary/10">
                   <Activity className="h-4 w-4 text-primary mx-auto mb-1" />
                   <p className="text-2xl font-bold text-primary">{totalMatches}</p>
@@ -148,7 +148,7 @@ const PlayerDashboard = () => {
           </CardContent>
         </Card>
 
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Card>
             <CardContent className="p-4">
               <p className="text-xs uppercase tracking-wider text-muted-foreground">Unread messages</p>
@@ -183,7 +183,7 @@ const PlayerDashboard = () => {
         </div>
 
         <Tabs defaultValue="stats">
-          <TabsList className="flex flex-wrap h-auto gap-1">
+          <TabsList className="flex h-auto w-full flex-wrap justify-center gap-2 rounded-[1.25rem] border border-primary/10 bg-white p-2">
             <TabsTrigger value="stats" className="flex items-center gap-1"><BarChart3 className="h-4 w-4" /> Career Stats</TabsTrigger>
             <TabsTrigger value="messages" className="flex items-center gap-1">
               <MessageSquare className="h-4 w-4" /> Messages


### PR DESCRIPTION
### Motivation
- Consolidate the app's visual system to a single centered, medium-width layout with a limited green/white/red palette and medium font sizes to reduce overlap and improve visual harmony. 
- Apply the redesign at the global theme and shared primitives so all pages follow the same centered card-and-stack rhythm without changing app behavior. 
- Make cards, buttons, inputs and top-level shells feel softer and more consistent to reduce visual noise and layout collisions.

### Description
- Refresh global design tokens and utilities in `src/index.css` to use the green/white/red palette, add `center-page` / `center-stack` helpers, increase radii and adjust shadows and baseline font sizing. 
- Update core UI primitives in `src/components/ui/` (`button.tsx`, `card.tsx`, `input.tsx`) to medium sizing, adjusted radii, updated shadows, and color classes so controls match the new theme. 
- Replace the top navigation with a centered, medium-width `Navbar` and adjust its item layout and mobile sheet styling in `src/components/Navbar.tsx`. 
- Convert main pages (`src/pages/Home.tsx`, `src/pages/Login.tsx`, `src/pages/AdminDashboard.tsx`, `src/pages/PlayerDashboard.tsx`) to use the centered shells, stacked hero/cards, and updated spacing so layouts are centered and overlaps are reduced; no product logic was changed. 

### Testing
- Ran `git diff --check` which produced no style errors. 
- Attempted `npm run build` and `npm run test` but both failed to run in this environment because the local `vite` / `vitest` binaries were not available and dependency installation was blocked by registry `403` responses. 
- Dependency installation attempts (`npm install` / `bun install`) also failed due to registry access being blocked, so build/test verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0d8a6718832c9369f925ebfaedc7)