### PR TITLE
Add Google Consent Mode bootstrap to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+      window.gtag = window.gtag || gtag;
+      window.gtag("consent", "default", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "denied",
+        functionality_storage: "granted",
+        personalization_storage: "denied",
+        security_storage: "granted",
+        wait_for_update: 500,
+      });
+    </script>
     <!-- TODO: Set the document title to the name of your application -->
     <title>Lovable App</title>
     <meta name="description" content="Lovable Generated Project">


### PR DESCRIPTION
### Motivation
- Ensure Google Consent Mode is initialized before any third-party Google tags to prevent "loaded before Consent Mode update" sequencing errors.
- Default to denying ad and analytics storage while preserving functionality and security storage so core site features continue to work until explicit consent is given.
- Repository contains no local Meta/TikTok/RudderStack/Osano integrations, so duplicate-pixel and invalid-event warnings appear to originate from the hosting/publishing environment rather than this app source.

### Description
- Inserted an inline bootstrap script at the top of `index.html` that initializes `window.dataLayer` and a `gtag` shim and exposes `window.gtag` for later tags.
- Call `gtag("consent", "default", {...})` with `ad_storage` and `analytics_storage` denied and `functionality_storage`/`security_storage` granted, and set `wait_for_update: 500` to allow consent updates before tags act.
- Kept the change limited to the HTML entry so consent defaults are present before any hosted/injected analytics scripts run.

### Testing
- Ran `npm run build`, which failed in this environment because `vite`/project dependencies are not installed, so a full production build validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1176c384832c80d05a535d2b1826)