### PR TITLE
Link registrations to seasons, prevent duplicates, and add secure PDF background pattern

### DIFF
--- a/public/google-apps-script-v2.js
+++ b/public/google-apps-script-v2.js
@@ -28,8 +28,8 @@
 // votes: ["vote_id","election_id","role_name","voter_user_id","voter_name","nominee_user_id","nominee_name","submitted_at","immutable_hash"],
 // nominations: ["nomination_id","election_id","role_name","nominee_user_id","nominee_name","proposer_user_id","proposer_name","manifesto","status","reviewed_by","reviewed_at","created_at"],
 // election_terms: ["assignment_id","election_id","role_name","user_id","user_name","term_start","term_end","assigned_at","source_vote_count"],
-// tournaments_v2: ["tournament_id","name","format","venue","start_date","end_date","registration_deadline","created_by","created_at","status","notes"],
-// registrations: ["registration_id","tournament_id","team_name","contact_name","contact_email","contact_phone","players_json","submitted_by","submitted_by_name","submitted_at","status","reviewed_by","reviewed_at","review_notes"],
+// tournaments_v2: ["tournament_id","name","format","venue","start_date","end_date","registration_deadline","created_by","created_at","status","notes","season_id","season_year","source_type","public_page_path"],
+// registrations: ["registration_id","tournament_id","tournament_name","season_id","season_year","registration_key","team_name","contact_name","contact_email","contact_phone","players_json","submitted_by","submitted_by_name","submitted_at","status","reviewed_by","reviewed_at","review_notes"],
 // schedules: ["schedule_id","tournament_id","tournament_name","version_number","matches_json","created_by","created_by_name","timestamp","change_log","status","parent_schedule_id","hash","rejection_reason"],
 // approvals: ["approval_id","schedule_id","approver_id","approver_name","approver_role","decision","comments","timestamp"],
 //

--- a/public/google-apps-script.js
+++ b/public/google-apps-script.js
@@ -88,8 +88,8 @@ const TABS = {
   votes: ["vote_id","election_id","role_name","voter_user_id","voter_name","nominee_user_id","nominee_name","submitted_at","immutable_hash"],
   nominations: ["nomination_id","election_id","role_name","nominee_user_id","nominee_name","proposer_user_id","proposer_name","manifesto","status","reviewed_by","reviewed_at","created_at"],
   election_terms: ["assignment_id","election_id","role_name","user_id","user_name","term_start","term_end","assigned_at","source_vote_count"],
-  tournaments_v2: ["tournament_id","name","format","venue","start_date","end_date","registration_deadline","created_by","created_at","status","notes"],
-  registrations: ["registration_id","tournament_id","team_name","contact_name","contact_email","contact_phone","players_json","submitted_by","submitted_by_name","submitted_at","status","reviewed_by","reviewed_at","review_notes"],
+  tournaments_v2: ["tournament_id","name","format","venue","start_date","end_date","registration_deadline","created_by","created_at","status","notes","season_id","season_year","source_type","public_page_path"],
+  registrations: ["registration_id","tournament_id","tournament_name","season_id","season_year","registration_key","team_name","contact_name","contact_email","contact_phone","players_json","submitted_by","submitted_by_name","submitted_at","status","reviewed_by","reviewed_at","review_notes"],
   schedules: ["schedule_id","tournament_id","tournament_name","version_number","matches_json","created_by","created_by_name","timestamp","change_log","status","parent_schedule_id","hash","rejection_reason"],
   approvals: ["approval_id","schedule_id","approver_id","approver_name","approver_role","decision","comments","timestamp"],
 };
@@ -408,6 +408,22 @@ function doPost(e) {
   const keyCol = getKeyColumn(tabName);
 
   if (action === "add") {
+    if (tabName === "registrations") {
+      const existing = sheetToJson(sheet);
+      const incomingKey = String((data && data.registration_key) || '').trim();
+      const normalizedTeam = String((data && data.team_name) || '').trim().toLowerCase().replace(/\s+/g, ' ');
+      const incomingTournament = String((data && data.tournament_id) || '').trim();
+      const incomingSeason = String((data && data.season_id) || '').trim();
+      const duplicate = existing.some((row) => {
+        const rowKey = String((row && row.registration_key) || '').trim();
+        if (incomingKey && rowKey) return rowKey === incomingKey;
+        const rowTeam = String((row && row.team_name) || '').trim().toLowerCase().replace(/\s+/g, ' ');
+        return String((row && row.tournament_id) || '').trim() === incomingTournament && String((row && row.season_id) || '').trim() === incomingSeason && rowTeam === normalizedTeam;
+      });
+      if (duplicate) {
+        return ContentService.createTextOutput(JSON.stringify({ success: false, error: "Duplicate registration" })).setMimeType(ContentService.MimeType.JSON);
+      }
+    }
     const row = headers.map((h) => (data[h] !== undefined ? data[h] : ""));
     sheet.appendRow(row);
     return ContentService.createTextOutput(JSON.stringify({ success: true })).setMimeType(ContentService.MimeType.JSON);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import AdminScorelistsPage from "./pages/AdminScorelistsPage";
 import LiveMatchPage from "./pages/LiveMatchPage";
 import ElectionsPage from '@/elections/ElectionsPage';
 import TournamentsHubPage from '@/tournaments/TournamentsHubPage';
+import RegistrationTournamentPage from '@/tournaments/RegistrationTournamentPage';
 import { RequireAuth } from '@/components/RequireAuth';
 
 const queryClient = new QueryClient();
@@ -52,6 +53,7 @@ const App = () => (
             <Route path="/management" element={<ManagementPage />} />
             <Route path="/elections" element={<RequireAuth><ElectionsPage /></RequireAuth>} />
             <Route path="/tournaments" element={<RequireAuth><TournamentsHubPage /></RequireAuth>} />
+            <Route path="/tournaments/registration/:id" element={<RequireAuth><RegistrationTournamentPage /></RequireAuth>} />
             <Route path="/live" element={<LiveMatchPage />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/lib/scorelistSecurePattern.ts
+++ b/src/lib/scorelistSecurePattern.ts
@@ -1,0 +1,82 @@
+function hashString(input: string) {
+  let hash = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function encodeSvg(svg: string) {
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+export interface SecurePatternOptions {
+  matchId: string;
+  checksum: string;
+  timestamp: string;
+  enableSecurePattern?: boolean;
+}
+
+export interface SecurePatternLayer {
+  enabled: boolean;
+  microtext: string;
+  backgroundImage: string;
+  style: string;
+}
+
+export function buildSecurePatternLayer(options: SecurePatternOptions): SecurePatternLayer {
+  const microtext = `MATCH-${options.matchId || 'NA'}-${options.checksum}-${options.timestamp}`;
+  if (!options.enableSecurePattern) {
+    return { enabled: false, microtext, backgroundImage: '', style: '' };
+  }
+
+  const seed = hashString(microtext);
+  const width = 900;
+  const height = 1200;
+  const spacing = 14 + (seed % 7);
+  const amplitude = 4 + (seed % 5);
+  const phase = (seed % 360) * (Math.PI / 180);
+  const altSpacing = spacing + 9;
+  const altAmplitude = amplitude + 2;
+
+  const lines: string[] = [];
+  for (let y = -40; y <= height + 40; y += spacing) {
+    const c1 = y + Math.sin((y + phase) / 48) * amplitude;
+    const c2 = y + Math.cos((y + phase) / 57) * (amplitude + 1);
+    const end = y + Math.sin((y + phase) / 63) * amplitude;
+    lines.push(`<path d="M -40 ${y.toFixed(2)} C ${width * 0.25} ${c1.toFixed(2)}, ${width * 0.65} ${c2.toFixed(2)}, ${width + 40} ${end.toFixed(2)}" />`);
+  }
+
+  for (let y = -60; y <= height + 60; y += altSpacing) {
+    const c1 = y + Math.cos((y + phase) / 39) * altAmplitude;
+    const c2 = y + Math.sin((y + phase) / 44) * (altAmplitude + 1);
+    const end = y + Math.cos((y + phase) / 52) * altAmplitude;
+    lines.push(`<path d="M -20 ${y.toFixed(2)} C ${width * 0.3} ${c1.toFixed(2)}, ${width * 0.7} ${c2.toFixed(2)}, ${width + 20} ${end.toFixed(2)}" class="alt" />`);
+  }
+
+  const hiddenText = Array.from({ length: 8 }, (_, index) => {
+    const x = 36 + (index % 2) * (width / 2);
+    const y = 90 + index * 120;
+    return `<text x="${x}" y="${y}" class="micro">${microtext}</text>`;
+  }).join('');
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <defs>
+      <style>
+        .wave { fill: none; stroke: rgba(22, 101, 52, 0.20); stroke-width: 0.7; }
+        .alt { fill: none; stroke: rgba(14, 116, 144, 0.14); stroke-width: 0.5; }
+        .micro { fill: rgba(22, 101, 52, 0.12); font-size: 5px; letter-spacing: 0.9px; font-family: Arial, sans-serif; }
+      </style>
+    </defs>
+    <rect width="100%" height="100%" fill="white" fill-opacity="0" />
+    <g class="wave">${lines.join('')}</g>
+    ${hiddenText}
+  </svg>`;
+
+  return {
+    enabled: true,
+    microtext,
+    backgroundImage: encodeSvg(svg),
+    style: `background-image:url("${encodeSvg(svg)}");background-repeat:repeat;background-size:680px 920px;opacity:0.16;`,
+  };
+}

--- a/src/pages/AdminScorelistsPage.tsx
+++ b/src/pages/AdminScorelistsPage.tsx
@@ -14,6 +14,7 @@ import { v2api, logAudit } from '@/lib/v2api';
 import { DigitalScorelist, CertificationApproval, ManagementUser } from '@/lib/v2types';
 import { getScorelistDetailedStatus, getScorelistRoadmap, readScorelistCertifications, resolveStageFromDesignation, scorelistStageLabels, scorelistStageOrder } from '@/lib/workflowStatus';
 import { verifyScorelist, exportScorelistAsJSON, generateMatchScorelist, generateTournamentScorelist } from '@/lib/scorelist';
+import { buildSecurePatternLayer } from '@/lib/scorelistSecurePattern';
 import { sendScorelistApprovalRequestBulk, getAdminNotificationRecipient, explainMailFailure } from '@/lib/mailer';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2, FileJson, ShieldCheck, ShieldX, Lock, Eye, Download, CheckCircle2, FileText } from 'lucide-react';
@@ -274,11 +275,18 @@ const AdminScorelistsPage = () => {
       </div>`;
     }).join('');
 
+    const securePattern = buildSecurePatternLayer({
+      matchId: sl.match_id || payloadMatches[0]?.match_id || 'TOURNAMENT',
+      checksum: sl.hash_digest.substring(0, 12),
+      timestamp: String(sl.generated_at || '').replace(/[^0-9A-Za-z]/g, ''),
+      enableSecurePattern: true,
+    });
+
     const html = `<!DOCTYPE html><html><head><title>Scorelist ${sl.scorelist_id}</title>
 <style>body{font-family:Arial,sans-serif;margin:40px;color:#1a1a1a;position:relative;background:#fff}h1{text-align:center;color:#1e6b3a}h2{color:#1e6b3a;border-bottom:2px solid #1e6b3a;padding-bottom:4px}
 table{width:100%;border-collapse:collapse;margin:10px 0}th,td{border:1px solid #ddd;padding:6px 8px;font-size:12px}th{background:#f0f7f0;text-align:left}
 .scoreboard{display:flex;justify-content:space-around;text-align:center;background:#f0f7f0;padding:20px;border-radius:8px;margin:20px 0}
-.team-score{font-size:28px;font-weight:bold;color:#1e6b3a}.watermark{position:fixed;top:40%;left:10%;transform:rotate(-30deg);font-size:80px;color:rgba(30,107,58,0.04);white-space:nowrap;pointer-events:none;z-index:-1}
+.team-score{font-size:28px;font-weight:bold;color:#1e6b3a}.watermark{position:fixed;top:40%;left:10%;transform:rotate(-30deg);font-size:80px;color:rgba(30,107,58,0.04);white-space:nowrap;pointer-events:none;z-index:-1}.secure-pattern{position:fixed;inset:0;pointer-events:none;z-index:-3}
 .footer{text-align:center;font-size:9px;color:#999;margin-top:30px;border-top:1px solid #ddd;padding-top:10px}
 .certified{background:#e8f5e9;border:2px solid #1e6b3a;text-align:center;padding:12px;border-radius:8px;font-weight:bold;color:#1e6b3a;margin:20px 0}
 .match-book-page{page-break-before:always}
@@ -290,10 +298,11 @@ table{width:100%;border-collapse:collapse;margin:10px 0}th,td{border:1px solid #
 .cert-grid{border:1px solid #b7d5c0;background-image:linear-gradient(rgba(30,107,58,0.08) 1px, transparent 1px),linear-gradient(90deg, rgba(30,107,58,0.08) 1px, transparent 1px);background-size:18px 18px;padding:8px;border-radius:8px}
 .status-chip{display:inline-block;margin:8px auto 0;padding:4px 10px;border-radius:999px;background:#e8f5e9;border:1px solid #8ac8a1;color:#145c36;font-weight:bold;font-size:11px}.verification-panel{display:flex;gap:18px;align-items:center;justify-content:space-between;margin:18px 0 24px;padding:16px 18px;border:1px solid #b7d5c0;border-radius:12px;background:linear-gradient(135deg, rgba(232,245,233,0.9), rgba(244,250,246,0.98))}.verification-copy{flex:1}.verification-copy p{margin:4px 0}.verification-url{font-family:monospace;font-size:11px;word-break:break-all;color:#145c36}.verification-qr{display:flex;align-items:center;justify-content:center;padding:10px;border-radius:12px;border:1px solid #9cc8ab;background:#fff;box-shadow:inset 0 0 0 4px rgba(30,107,58,0.06)}.security-features{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin:18px 0 22px}.security-feature-card{border:1px solid #b7d5c0;border-radius:10px;background:#fcfefd;padding:12px 14px}.security-feature-card p{margin:6px 0 0;font-size:11px;line-height:1.45;color:#355244}.security-feature-title{font-weight:700;color:#124928}.security-seal{display:inline-flex;align-items:center;gap:8px;padding:7px 12px;border-radius:999px;border:1px solid #7ab28d;background:#fff;color:#145c36;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em}
 @media print{.watermark{display:block}}</style></head><body>
+${securePattern.enabled ? `<div class="secure-pattern" style="${securePattern.style}"></div>` : ''}
 <div class="security-grid"></div>
 <div class="security-thread left"></div>
 <div class="security-thread right"></div>
-<div class="microtext">MICROTEXT • ${sl.scorelist_id} • ${verifyUrl} • DIGITAL CERTIFIED RECORD • MICROTEXT</div>
+<div class="microtext">MICROTEXT • ${sl.scorelist_id} • ${verifyUrl} • DIGITAL CERTIFIED RECORD • MICROTEXT${securePattern.enabled ? ` • ${securePattern.microtext}` : ''}</div>
 <div class="watermark">VERIFIED MATCH RECORD</div>
 <p style="text-align:center;font-size:10px;text-transform:uppercase;letter-spacing:3px;color:#666">Cricket Club Portal</p>
 <h1 class="intaglio">Digital ${sl.scope_type === 'match' ? 'Match' : 'Tournament'} Scorelist</h1>

--- a/src/tournaments/RegistrationTournamentPage.tsx
+++ b/src/tournaments/RegistrationTournamentPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Calendar, ClipboardList, MapPin } from 'lucide-react';
+import { Navbar } from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { tournamentService } from './tournamentService';
+import { RegistrationRecord, TournamentRegistryRecord } from './types';
+import { useAuth } from '@/lib/auth';
+import { normalizeId } from '@/lib/dataUtils';
+
+const RegistrationTournamentPage = () => {
+  const { id } = useParams();
+  const { user } = useAuth();
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    tournamentService.syncFromBackend().finally(() => setRefreshKey((value) => value + 1));
+  }, []);
+
+  if (!user) return <Navigate to="/login" replace />;
+
+  const tournamentId = normalizeId(id);
+  const tournaments = useMemo(() => tournamentService.getTournaments(), [refreshKey]);
+  const registrations = useMemo(() => tournamentService.getRegistrations(), [refreshKey]);
+  const tournament = tournaments.find((item) => normalizeId(item.tournament_id) === tournamentId) as TournamentRegistryRecord | undefined;
+
+  if (!tournament) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Navbar />
+        <div className="container mx-auto px-4 py-20 text-center space-y-4">
+          <h1 className="font-display text-3xl font-bold">Registration page not found</h1>
+          <Button asChild><Link to="/tournaments">Back to tournament registrations</Link></Button>
+        </div>
+      </div>
+    );
+  }
+
+  const tournamentRegistrations = registrations.filter((item) => normalizeId(item.tournament_id) === tournamentId);
+  const groupedBySeason = tournamentRegistrations.reduce<Record<string, RegistrationRecord[]>>((acc, item) => {
+    const key = `${item.season_id || 'NA'}::${item.season_year || 'Open'}`;
+    acc[key] = acc[key] || [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/tournaments"><ArrowLeft className="h-4 w-4 mr-1" /> Back</Link>
+          </Button>
+          <Badge variant="outline">Custom registration page</Badge>
+        </div>
+
+        <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
+          <CardContent className="p-6 space-y-4">
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+              <div>
+                <h1 className="font-display text-3xl font-bold">{tournament.name}</h1>
+                <p className="text-muted-foreground mt-1">{tournament.format} registration campaign</p>
+              </div>
+              <Badge variant={tournament.status === 'open' ? 'default' : 'secondary'}>{tournament.status}</Badge>
+            </div>
+            <div className="grid gap-3 md:grid-cols-3 text-sm">
+              <div className="rounded-lg border p-3"><Calendar className="h-4 w-4 mb-2 text-primary" />Season year: <strong>{tournament.season_year || 'Not linked'}</strong></div>
+              <div className="rounded-lg border p-3"><MapPin className="h-4 w-4 mb-2 text-primary" />Venue: <strong>{tournament.venue || 'TBD'}</strong></div>
+              <div className="rounded-lg border p-3"><ClipboardList className="h-4 w-4 mb-2 text-primary" />Deadline: <strong>{tournament.registration_deadline || 'Not set'}</strong></div>
+            </div>
+            <p className="text-sm text-muted-foreground">{tournament.notes || 'This registration page was created for a tournament that is not yet part of the main tournaments catalogue.'}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>Registrations received</CardTitle></CardHeader>
+          <CardContent className="space-y-4">
+            {Object.entries(groupedBySeason).map(([key, items]) => (
+              <div key={key} className="rounded-lg border p-4 space-y-3">
+                <div className="flex items-center justify-between gap-2 flex-wrap">
+                  <p className="font-semibold">Season {items[0]?.season_year || 'Open'}{items[0]?.season_id ? ` • ${items[0].season_id}` : ''}</p>
+                  <Badge variant="outline">{items.length} registration(s)</Badge>
+                </div>
+                {items.map((registration) => (
+                  <div key={registration.registration_id} className="rounded-md border bg-muted/20 p-3 text-sm">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                      <span className="font-medium">{registration.team_name}</span>
+                      <Badge variant={registration.status === 'approved' ? 'default' : registration.status === 'rejected' ? 'destructive' : 'secondary'}>{registration.status}</Badge>
+                    </div>
+                    <p className="text-muted-foreground mt-1">Contact: {registration.contact_name} · {registration.contact_email}</p>
+                  </div>
+                ))}
+              </div>
+            ))}
+            {tournamentRegistrations.length === 0 && <p className="text-sm text-muted-foreground">No registrations submitted yet.</p>}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default RegistrationTournamentPage;

--- a/src/tournaments/TournamentsHubPage.tsx
+++ b/src/tournaments/TournamentsHubPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
+import { Calendar, ExternalLink, Link2, ShieldCheck } from 'lucide-react';
 import { Navbar } from '@/components/Navbar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -13,17 +14,23 @@ import { useToast } from '@/hooks/use-toast';
 import { tournamentService } from './tournamentService';
 import { scheduleService } from '@/schedules/scheduleService';
 import { ScheduleMatch } from '@/schedules/types';
+import { useData } from '@/lib/DataContext';
+import { normalizeId } from '@/lib/dataUtils';
+
+const emptyScheduleRow: ScheduleMatch = { match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' };
 
 const TournamentsHubPage = () => {
   const { user } = useAuth();
   const { toast } = useToast();
+  const { tournaments: catalogTournaments, seasons } = useData();
   const [refreshKey, setRefreshKey] = useState(0);
   const [selectedTournament, setSelectedTournament] = useState('');
-  const [tournamentForm, setTournamentForm] = useState({ name: '', format: 'T20', venue: '', start_date: '', end_date: '', registration_deadline: '', notes: '' });
+  const [selectedSeason, setSelectedSeason] = useState('');
+  const [tournamentForm, setTournamentForm] = useState({ name: '', format: 'T20', venue: '', start_date: '', end_date: '', registration_deadline: '', notes: '', season_year: String(new Date().getFullYear()) });
   const [registrationForm, setRegistrationForm] = useState({ team_name: '', contact_name: '', contact_email: '', contact_phone: '', players: '' });
   const [reviewNotes, setReviewNotes] = useState<Record<string, string>>({});
   const [approvalComments, setApprovalComments] = useState<Record<string, string>>({});
-  const [scheduleDraft, setScheduleDraft] = useState<ScheduleMatch[]>([{ match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' }]);
+  const [scheduleDraft, setScheduleDraft] = useState<ScheduleMatch[]>([emptyScheduleRow]);
   const [changeLog, setChangeLog] = useState('');
 
   useEffect(() => {
@@ -32,48 +39,109 @@ const TournamentsHubPage = () => {
 
   if (!user) return <Navigate to="/login" replace />;
 
-  const tournaments = useMemo(() => tournamentService.getTournaments(), [refreshKey]);
+  const registryTournaments = useMemo(() => tournamentService.getTournaments(), [refreshKey]);
   const registrations = useMemo(() => tournamentService.getRegistrations(), [refreshKey]);
-  const activeTournament = tournaments.find((item) => item.tournament_id === selectedTournament) || tournaments[0];
-  const activeRegistrations = registrations.filter((item) => item.tournament_id === activeTournament?.tournament_id);
-  const approvedSchedules = activeTournament ? scheduleService.getApprovedSchedulesForTournament(activeTournament.tournament_id) : [];
+
+  const existingSeasonOptions = useMemo(() =>
+    seasons
+      .map((season) => {
+        const tournament = catalogTournaments.find((item) => normalizeId(item.tournament_id) === normalizeId(season.tournament_id));
+        return tournament ? {
+          key: `${tournament.tournament_id}::${season.season_id}`,
+          tournament_id: tournament.tournament_id,
+          season_id: season.season_id,
+          season_year: season.year,
+          tournament_name: tournament.name,
+          format: tournament.format,
+          venue: tournament.description || 'Existing tournament season',
+          publicPath: `/tournament/${tournament.tournament_id}#season-${season.season_id}`,
+          source_type: 'existing' as const,
+        } : null;
+      })
+      .filter(Boolean),
+  [catalogTournaments, seasons]);
+
+  const customTournamentOptions = useMemo(() => registryTournaments.map((item) => ({
+    key: `${item.tournament_id}::${item.season_id || 'NA'}`,
+    tournament_id: item.tournament_id,
+    season_id: item.season_id || '',
+    season_year: item.season_year || '',
+    tournament_name: item.name,
+    format: item.format,
+    venue: item.venue,
+    publicPath: item.public_page_path || `/tournaments/registration/${item.tournament_id}`,
+    source_type: (item.source_type || 'custom') as 'custom',
+  })), [registryTournaments]);
+
+  const registrationTargets = [...existingSeasonOptions, ...customTournamentOptions];
+  const activeTarget = registrationTargets.find((item) => item.key === `${selectedTournament}::${selectedSeason}`) || registrationTargets[0];
+
+  useEffect(() => {
+    if (!activeTarget) return;
+    setSelectedTournament(activeTarget.tournament_id);
+    setSelectedSeason(activeTarget.season_id);
+  }, [activeTarget?.key]);
+
+  const activeRegistrations = registrations.filter((item) => normalizeId(item.tournament_id) === normalizeId(activeTarget?.tournament_id) && normalizeId(item.season_id) === normalizeId(activeTarget?.season_id));
+  const approvedSchedules = activeTarget ? scheduleService.getApprovedSchedulesForTournament(activeTarget.tournament_id) : [];
 
   const createTournament = async () => {
     if (!user || !canManageTournament(user)) return;
-    const record = await tournamentService.createTournament({ ...tournamentForm, created_by: getActorId(user), status: 'open' }, user);
+    const year = Number(tournamentForm.season_year) || tournamentForm.season_year;
+    const record = await tournamentService.createTournament({
+      name: tournamentForm.name,
+      format: tournamentForm.format,
+      venue: tournamentForm.venue,
+      start_date: tournamentForm.start_date,
+      end_date: tournamentForm.end_date,
+      registration_deadline: tournamentForm.registration_deadline,
+      notes: tournamentForm.notes,
+      created_by: getActorId(user),
+      status: 'open',
+      season_year: year,
+      source_type: 'custom',
+      public_page_path: '',
+    }, user);
     setSelectedTournament(record.tournament_id);
-    setTournamentForm({ name: '', format: 'T20', venue: '', start_date: '', end_date: '', registration_deadline: '', notes: '' });
+    setSelectedSeason('');
+    setTournamentForm({ name: '', format: 'T20', venue: '', start_date: '', end_date: '', registration_deadline: '', notes: '', season_year: String(new Date().getFullYear()) });
     setRefreshKey((value) => value + 1);
-    toast({ title: 'Tournament created', description: 'Registration is now open for members.' });
+    toast({ title: 'Tournament registration page created', description: 'This new competition now has its own dedicated registration page.' });
   };
 
   const submitRegistration = async () => {
-    if (!activeTournament || !user) return;
-    await tournamentService.submitRegistration({
-      tournament_id: activeTournament.tournament_id,
-      team_name: registrationForm.team_name,
-      contact_name: registrationForm.contact_name,
-      contact_email: registrationForm.contact_email,
-      contact_phone: registrationForm.contact_phone,
-      players_json: JSON.stringify(registrationForm.players.split('\n').map((item) => item.trim()).filter(Boolean)),
-      submitted_by: getActorId(user),
-      submitted_by_name: getActorName(user),
-    }, user);
-    setRegistrationForm({ team_name: '', contact_name: '', contact_email: '', contact_phone: '', players: '' });
-    setRefreshKey((value) => value + 1);
-    toast({ title: 'Registration submitted', description: 'Your team registration is pending Tournament Director approval.' });
+    if (!activeTarget || !user) return;
+    try {
+      await tournamentService.submitRegistration({
+        tournament_id: activeTarget.tournament_id,
+        tournament_name: activeTarget.tournament_name,
+        season_id: activeTarget.season_id,
+        season_year: activeTarget.season_year,
+        team_name: registrationForm.team_name,
+        contact_name: registrationForm.contact_name,
+        contact_email: registrationForm.contact_email,
+        contact_phone: registrationForm.contact_phone,
+        players_json: JSON.stringify(registrationForm.players.split('\n').map((item) => item.trim()).filter(Boolean)),
+        submitted_by: getActorId(user),
+        submitted_by_name: getActorName(user),
+      }, user);
+      setRegistrationForm({ team_name: '', contact_name: '', contact_email: '', contact_phone: '', players: '' });
+      setRefreshKey((value) => value + 1);
+      toast({ title: 'Registration submitted', description: 'Your team registration is pending Tournament Director approval.' });
+    } catch (error) {
+      toast({ title: 'Registration blocked', description: error instanceof Error ? error.message : 'Duplicate registration detected.', variant: 'destructive' });
+    }
   };
 
-
   const createScheduleVersion = async () => {
-    if (!activeTournament || !user || !canManageTournament(user)) return;
+    if (!activeTarget || !user || !canManageTournament(user)) return;
     await scheduleService.createVersion({
-      tournament_id: activeTournament.tournament_id,
-      tournament_name: activeTournament.name,
+      tournament_id: activeTarget.tournament_id,
+      tournament_name: activeTarget.tournament_name,
       matches: scheduleDraft.filter((item) => item.match_id && item.team_a && item.team_b),
       change_log: changeLog,
     }, user);
-    setScheduleDraft([{ match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' }]);
+    setScheduleDraft([emptyScheduleRow]);
     setChangeLog('');
     setRefreshKey((value) => value + 1);
     toast({ title: 'Schedule draft saved', description: 'A new version has been created and previous versions remain archived.' });
@@ -117,7 +185,7 @@ const TournamentsHubPage = () => {
           <div>
             <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Competition Ops</p>
             <h1 className="font-display text-3xl font-bold">Tournament Registration</h1>
-            <p className="text-muted-foreground">Create tournaments, register teams, review approvals, and monitor approved schedule versions.</p>
+            <p className="text-muted-foreground">Registrations now link directly to existing tournament seasons, while brand-new competitions get their own separate registration page.</p>
           </div>
           <div className="flex gap-2 flex-wrap">
             {tournamentService.getTables().map((table) => <Badge key={table} variant="outline">Table: {table}</Badge>)}
@@ -127,49 +195,61 @@ const TournamentsHubPage = () => {
 
         {canManageTournament(user) && (
           <Card>
-            <CardHeader><CardTitle>Create Tournament</CardTitle></CardHeader>
+            <CardHeader><CardTitle>Create Separate Registration Tournament</CardTitle></CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2">
               {Object.entries(tournamentForm).map(([key, value]) => (
                 <div key={key} className={`space-y-2 ${key === 'notes' ? 'md:col-span-2' : ''}`}>
                   <Label>{key.replace(/_/g, ' ')}</Label>
                   {key === 'notes'
                     ? <Textarea value={value} onChange={(e) => setTournamentForm((prev) => ({ ...prev, [key]: e.target.value }))} />
-                    : <Input type={key.includes('date') ? 'date' : 'text'} value={value} onChange={(e) => setTournamentForm((prev) => ({ ...prev, [key]: e.target.value }))} />}
+                    : <Input type={key.includes('date') ? 'date' : key === 'season_year' ? 'number' : 'text'} value={value} onChange={(e) => setTournamentForm((prev) => ({ ...prev, [key]: e.target.value }))} />}
                 </div>
               ))}
-              <Button onClick={createTournament} disabled={!tournamentForm.name.trim()}>Create Tournament</Button>
+              <Button onClick={createTournament} disabled={!tournamentForm.name.trim()}>Create Registration Page</Button>
             </CardContent>
           </Card>
         )}
 
-        <div className="grid gap-6 lg:grid-cols-[0.9fr,1.1fr]">
+        <div className="grid gap-6 lg:grid-cols-[0.95fr,1.05fr]">
           <Card>
-            <CardHeader><CardTitle>Available Tournaments</CardTitle></CardHeader>
+            <CardHeader><CardTitle>Registration Targets</CardTitle></CardHeader>
             <CardContent className="space-y-3">
-              {tournaments.length === 0 && <p className="text-sm text-muted-foreground">No tournament registry records yet.</p>}
-              {tournaments.map((item) => (
-                <button key={item.tournament_id} className={`w-full rounded-lg border p-4 text-left ${activeTournament?.tournament_id === item.tournament_id ? 'border-primary bg-primary/5' : ''}`} onClick={() => setSelectedTournament(item.tournament_id)}>
-                  <div className="flex items-center justify-between gap-2 flex-wrap">
-                    <div>
-                      <p className="font-semibold">{item.name}</p>
-                      <p className="text-sm text-muted-foreground">{item.format} · {item.venue}</p>
+              {registrationTargets.length === 0 && <p className="text-sm text-muted-foreground">No tournament seasons are available for registration yet.</p>}
+              {registrationTargets.map((item) => {
+                const isActive = activeTarget?.key === item.key;
+                const targetRegistrations = registrations.filter((registration) => normalizeId(registration.tournament_id) === normalizeId(item.tournament_id) && normalizeId(registration.season_id) === normalizeId(item.season_id));
+                return (
+                  <button key={item.key} className={`w-full rounded-lg border p-4 text-left ${isActive ? 'border-primary bg-primary/5' : ''}`} onClick={() => { setSelectedTournament(item.tournament_id); setSelectedSeason(item.season_id); }}>
+                    <div className="flex items-start justify-between gap-3 flex-wrap">
+                      <div>
+                        <p className="font-semibold">{item.tournament_name}</p>
+                        <p className="text-sm text-muted-foreground">Season {item.season_year || 'Open'} • {item.format}</p>
+                        <p className="text-xs text-muted-foreground mt-1">{item.source_type === 'existing' ? 'Linked to existing tournament page' : 'Separate registration page'}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <Badge variant={item.source_type === 'existing' ? 'outline' : 'default'}>{item.source_type}</Badge>
+                        <Badge variant="secondary">{targetRegistrations.length} registration(s)</Badge>
+                      </div>
                     </div>
-                    <Badge variant={item.status === 'open' ? 'default' : 'secondary'}>{item.status}</Badge>
-                  </div>
-                </button>
-              ))}
+                  </button>
+                );
+              })}
             </CardContent>
           </Card>
 
-          {activeTournament && (
+          {activeTarget && (
             <Card>
-              <CardHeader><CardTitle>{activeTournament.name}</CardTitle></CardHeader>
+              <CardHeader><CardTitle>{activeTarget.tournament_name}</CardTitle></CardHeader>
               <CardContent className="space-y-5">
-                <div className="rounded-lg border p-4 text-sm space-y-1">
-                  <p><strong>Dates:</strong> {activeTournament.start_date} → {activeTournament.end_date}</p>
-                  <p><strong>Registration deadline:</strong> {activeTournament.registration_deadline || 'Not set'}</p>
-                  <p><strong>Notes:</strong> {activeTournament.notes || '—'}</p>
+                <div className="rounded-lg border p-4 text-sm space-y-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge variant="outline"><Calendar className="h-3 w-3 mr-1" />Season {activeTarget.season_year || 'Open'}</Badge>
+                    <Badge variant="outline">Tournament ID: {activeTarget.tournament_id}</Badge>
+                    {activeTarget.season_id && <Badge variant="outline">Season ID: {activeTarget.season_id}</Badge>}
+                  </div>
+                  <p><strong>Public page:</strong> <Link className="text-primary inline-flex items-center gap-1" to={activeTarget.publicPath}><Link2 className="h-3.5 w-3.5" /> Open linked page</Link></p>
                   <p><strong>Approved schedule versions:</strong> {approvedSchedules.length}</p>
+                  <p className="text-muted-foreground">Duplicate team registrations for the same tournament season are automatically blocked across the UI and sheet sync.</p>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="space-y-2">
@@ -187,13 +267,13 @@ const TournamentsHubPage = () => {
                     <Textarea className="min-h-[220px]" value={registrationForm.players} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, players: e.target.value }))} />
                   </div>
                 </div>
-                <Button onClick={submitRegistration} disabled={!registrationForm.team_name.trim()}>Submit Registration</Button>
+                <Button onClick={submitRegistration} disabled={!registrationForm.team_name.trim()}><ShieldCheck className="h-4 w-4 mr-1" /> Submit Registration</Button>
               </CardContent>
             </Card>
           )}
         </div>
 
-        {activeTournament && (
+        {activeTarget && (
           <Card>
             <CardHeader><CardTitle>Registrations</CardTitle></CardHeader>
             <CardContent className="space-y-4">
@@ -202,7 +282,7 @@ const TournamentsHubPage = () => {
                   <div className="flex items-center justify-between gap-2 flex-wrap">
                     <div>
                       <p className="font-semibold">{registration.team_name}</p>
-                      <p className="text-sm text-muted-foreground">Submitted by {registration.submitted_by_name} · {registration.contact_email}</p>
+                      <p className="text-sm text-muted-foreground">Season {registration.season_year || 'Open'} · Submitted by {registration.submitted_by_name} · {registration.contact_email}</p>
                     </div>
                     <Badge variant={registration.status === 'approved' ? 'default' : registration.status === 'rejected' ? 'destructive' : 'secondary'}>{registration.status}</Badge>
                   </div>
@@ -223,8 +303,7 @@ const TournamentsHubPage = () => {
           </Card>
         )}
 
-
-        {activeTournament && (
+        {activeTarget && (
           <Card>
             <CardHeader><CardTitle>Schedule Versions & Workflow</CardTitle></CardHeader>
             <CardContent className="space-y-4">
@@ -240,13 +319,13 @@ const TournamentsHubPage = () => {
                     </div>
                   ))}
                   <div className="flex gap-2 flex-wrap">
-                    <Button variant="outline" onClick={() => setScheduleDraft((prev) => [...prev, { match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' }])}>Add Match</Button>
+                    <Button variant="outline" onClick={() => setScheduleDraft((prev) => [...prev, emptyScheduleRow])}>Add Match</Button>
                     <Button onClick={createScheduleVersion}>Save Version</Button>
                   </div>
                 </div>
               )}
 
-              {[...scheduleService.getSchedules().filter((item) => item.tournament_id === activeTournament.tournament_id)].sort((a, b) => b.version_number - a.version_number).map((schedule) => {
+              {[...scheduleService.getSchedules().filter((item) => item.tournament_id === activeTarget.tournament_id)].sort((a, b) => b.version_number - a.version_number).map((schedule) => {
                 const previous = scheduleService.getSchedules().find((item) => item.schedule_id === schedule.parent_schedule_id);
                 const diff = scheduleService.diffVersions(previous, schedule);
                 const approvals = scheduleService.getApprovals().filter((item) => item.schedule_id === schedule.schedule_id);
@@ -286,6 +365,29 @@ const TournamentsHubPage = () => {
           </Card>
         )}
 
+        <Card>
+          <CardHeader><CardTitle>Quick links</CardTitle></CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2">
+            {existingSeasonOptions.map((item) => (
+              <div key={item.key} className="rounded-lg border p-4 flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">{item.tournament_name}</p>
+                  <p className="text-sm text-muted-foreground">Season {item.season_year} · existing tournament page</p>
+                </div>
+                <Button asChild size="sm" variant="outline"><Link to={item.publicPath}>Open <ExternalLink className="h-3.5 w-3.5 ml-1" /></Link></Button>
+              </div>
+            ))}
+            {customTournamentOptions.map((item) => (
+              <div key={item.key} className="rounded-lg border p-4 flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">{item.tournament_name}</p>
+                  <p className="text-sm text-muted-foreground">Season {item.season_year || 'Open'} · separate registration page</p>
+                </div>
+                <Button asChild size="sm" variant="outline"><Link to={item.publicPath}>Open <ExternalLink className="h-3.5 w-3.5 ml-1" /></Link></Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/tournaments/tournamentService.ts
+++ b/src/tournaments/tournamentService.ts
@@ -4,6 +4,14 @@ import { generateId } from '@/lib/utils';
 import { logAudit, v2api } from '@/lib/v2api';
 import { RegistrationRecord, TournamentAuditLog, TournamentRegistryRecord } from './types';
 
+function normalizeText(value: string) {
+  return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function buildRegistrationKey(input: Pick<RegistrationRecord, 'tournament_id' | 'season_id' | 'team_name'>) {
+  return [String(input.tournament_id || '').trim(), String(input.season_id || 'NA').trim(), normalizeText(input.team_name)].join('::');
+}
+
 const STORAGE = {
   tournaments: 'club:tournaments:registry',
   registrations: 'club:tournaments:registrations',
@@ -55,7 +63,7 @@ export const tournamentService = {
         v2api.getCustomSheet<RegistrationRecord>(SHEETS.registrations),
       ]);
       if (tournaments.length) write(STORAGE.tournaments, tournaments);
-      if (registrations.length) write(STORAGE.registrations, registrations);
+      if (registrations.length) write(STORAGE.registrations, registrations.map((item) => ({ ...item, registration_key: item.registration_key || buildRegistrationKey(item) })));
     } catch {
       // local cache remains the fallback
     }
@@ -64,7 +72,9 @@ export const tournamentService = {
     return read<TournamentRegistryRecord>(STORAGE.tournaments).sort((a, b) => b.created_at.localeCompare(a.created_at));
   },
   getRegistrations() {
-    return read<RegistrationRecord>(STORAGE.registrations).sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
+    return read<RegistrationRecord>(STORAGE.registrations)
+      .map((item) => ({ ...item, registration_key: item.registration_key || buildRegistrationKey(item) }))
+      .sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
   },
   getAuditLogs() {
     return read<TournamentAuditLog>(STORAGE.audit);
@@ -76,11 +86,19 @@ export const tournamentService = {
     appendAudit({ audit_id: generateId('TAUD'), module: 'tournaments', entity_type: 'tournament', entity_id: record.tournament_id, action: 'create_tournament', actor_id: getActorId(user), actor_name: getActorName(user), timestamp: new Date().toISOString(), details: JSON.stringify({ name: record.name, format: record.format, status: record.status }) });
     return record;
   },
-  async submitRegistration(input: Omit<RegistrationRecord, 'registration_id' | 'submitted_at' | 'status' | 'reviewed_by' | 'reviewed_at' | 'review_notes'>, user: AuthUser) {
-    const record: RegistrationRecord = { ...input, registration_id: generateId('REG'), submitted_at: new Date().toISOString(), status: 'pending', reviewed_by: '', reviewed_at: '', review_notes: '' };
+  isDuplicateRegistration(input: Pick<RegistrationRecord, 'tournament_id' | 'season_id' | 'team_name'>, ignoreRegistrationId?: string) {
+    const registrationKey = buildRegistrationKey(input);
+    return this.getRegistrations().some((item) => item.registration_id !== ignoreRegistrationId && (item.registration_key || buildRegistrationKey(item)) === registrationKey);
+  },
+  async submitRegistration(input: Omit<RegistrationRecord, 'registration_id' | 'submitted_at' | 'status' | 'reviewed_by' | 'reviewed_at' | 'review_notes' | 'registration_key'>, user: AuthUser) {
+    const registration_key = buildRegistrationKey(input);
+    if (this.isDuplicateRegistration(input)) {
+      throw new Error('A registration for this team already exists for the selected tournament season.');
+    }
+    const record: RegistrationRecord = { ...input, registration_key, registration_id: generateId('REG'), submitted_at: new Date().toISOString(), status: 'pending', reviewed_by: '', reviewed_at: '', review_notes: '' };
     write(STORAGE.registrations, [record, ...this.getRegistrations()]);
     await safeSyncRow('add', SHEETS.registrations, record);
-    appendAudit({ audit_id: generateId('TAUD'), module: 'tournaments', entity_type: 'registration', entity_id: record.registration_id, action: 'submit_registration', actor_id: getActorId(user), actor_name: getActorName(user), timestamp: new Date().toISOString(), details: JSON.stringify({ tournamentId: record.tournament_id, teamName: record.team_name }) });
+    appendAudit({ audit_id: generateId('TAUD'), module: 'tournaments', entity_type: 'registration', entity_id: record.registration_id, action: 'submit_registration', actor_id: getActorId(user), actor_name: getActorName(user), timestamp: new Date().toISOString(), details: JSON.stringify({ tournamentId: record.tournament_id, seasonId: record.season_id || '', teamName: record.team_name, registrationKey: record.registration_key }) });
     return record;
   },
   async reviewRegistration(registrationId: string, status: 'approved' | 'rejected', reviewNotes: string, user: AuthUser) {

--- a/src/tournaments/types.ts
+++ b/src/tournaments/types.ts
@@ -12,11 +12,19 @@ export interface TournamentRegistryRecord {
   created_at: string;
   status: 'open' | 'closed';
   notes: string;
+  season_id?: string;
+  season_year?: number | string;
+  source_type?: 'existing' | 'custom';
+  public_page_path?: string;
 }
 
 export interface RegistrationRecord {
   registration_id: string;
   tournament_id: string;
+  tournament_name?: string;
+  season_id?: string;
+  season_year?: number | string;
+  registration_key?: string;
   team_name: string;
   contact_name: string;
   contact_email: string;


### PR DESCRIPTION
### Motivation

- Ensure tournament registrations are explicitly linked to existing tournament seasons when available and provide separate registration pages for new competitions. 
- Prevent duplicate team registrations from being inserted into the Google Sheet (originating from UI or direct sheet writes). 
- Add a subtle, reusable secure background pattern (guilloché-style) with embedded microtext to scorelist PDF output for tamper-evidence without changing existing layout.

### Description

- UI and routing: enhance the tournaments hub so registration targets include existing catalog seasons and custom registration-only pages, add a dedicated `RegistrationTournamentPage`, and wire a new route at `/tournaments/registration/:id`. (changes in `src/tournaments/TournamentsHubPage.tsx`, `src/tournaments/RegistrationTournamentPage.tsx`, `src/App.tsx`).
- Data model & service: extend `TournamentRegistryRecord` and `RegistrationRecord` to include season linkage and a `registration_key`, implement `buildRegistrationKey()` and `isDuplicateRegistration()` to block duplicates at submit time, and persist normalized keys when syncing with backend sheets (`src/tournaments/types.ts`, `src/tournaments/tournamentService.ts`).
- Google Apps Script: update `TABS` definitions to include the new fields and add server-side duplicate detection in the `doPost` add-path for the `registrations` tab to reject duplicate inserts (so duplicates are blocked even if attempted directly against the sheet API) (`public/google-apps-script.js`, `public/google-apps-script-v2.js`).
- Secure PDF pattern: add a reusable module `buildSecurePatternLayer(options)` that generates an SVG-based fine wave/line guilloché pattern and embeds repeated microtext `MATCH-{matchId}-{checksum}-{timestamp}`; integrate it as a low-opacity background layer in the scorelist PDF HTML generation behind a runtime flag (`enableSecurePattern`) so existing layout/content remain unchanged (`src/lib/scorelistSecurePattern.ts`, `src/pages/AdminScorelistsPage.tsx`).
- Misc: updated PDF export HTML to place the pattern behind existing security layers and append the microtext string in the footer band; Apps Script header comments were updated to show the new sheet column names.

### Testing

- Type-check: ran `tsc --noEmit` which succeeded. 
- Functional checks: manual code integration wired the secure pattern into the existing scorelist HTML print flow and added duplicate checks in both the service and Apps Script path; UI registration flow now throws an error when a duplicate is detected and sheet API returns an error for duplicate writes. 
- Remaining automated checks: attempted `npm test` but the test runner (`vitest`) was not available in the environment and `npm install` could not complete due to registry access returning HTTP 403, and `eslint` could not run because dev dependencies were not installed. As a result full automated test/lint runs could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be19316d30832ca3c91ea774c3f704)