### PR TITLE
Make secure scorelist pattern visibly apparent

### DIFF
--- a/src/lib/scorelistSecurePattern.ts
+++ b/src/lib/scorelistSecurePattern.ts
@@ -22,12 +22,13 @@ export interface SecurePatternLayer {
   microtext: string;
   backgroundImage: string;
   style: string;
+  visibleLabel: string;
 }
 
 export function buildSecurePatternLayer(options: SecurePatternOptions): SecurePatternLayer {
   const microtext = `MATCH-${options.matchId || 'NA'}-${options.checksum}-${options.timestamp}`;
   if (!options.enableSecurePattern) {
-    return { enabled: false, microtext, backgroundImage: '', style: '' };
+    return { enabled: false, microtext, backgroundImage: '', style: '', visibleLabel: microtext };
   }
 
   const seed = hashString(microtext);
@@ -54,22 +55,34 @@ export function buildSecurePatternLayer(options: SecurePatternOptions): SecurePa
     lines.push(`<path d="M -20 ${y.toFixed(2)} C ${width * 0.3} ${c1.toFixed(2)}, ${width * 0.7} ${c2.toFixed(2)}, ${width + 20} ${end.toFixed(2)}" class="alt" />`);
   }
 
-  const hiddenText = Array.from({ length: 8 }, (_, index) => {
-    const x = 36 + (index % 2) * (width / 2);
-    const y = 90 + index * 120;
+  const hiddenText = Array.from({ length: 12 }, (_, index) => {
+    const x = 42 + (index % 3) * (width / 3.15);
+    const y = 96 + index * 86;
     return `<text x="${x}" y="${y}" class="micro">${microtext}</text>`;
+  }).join('');
+
+  const visibleLabel = `SECURE PATTERN • ${microtext}`;
+  const visibleBands = Array.from({ length: 4 }, (_, index) => {
+    const y = 170 + index * 230;
+    return `<g transform="translate(${width / 2}, ${y}) rotate(-24)">
+      <rect x="-260" y="-18" width="520" height="36" rx="18" class="label-band" />
+      <text text-anchor="middle" dominant-baseline="middle" class="visible-label">${visibleLabel}</text>
+    </g>`;
   }).join('');
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
     <defs>
       <style>
-        .wave { fill: none; stroke: rgba(22, 101, 52, 0.20); stroke-width: 0.7; }
-        .alt { fill: none; stroke: rgba(14, 116, 144, 0.14); stroke-width: 0.5; }
-        .micro { fill: rgba(22, 101, 52, 0.12); font-size: 5px; letter-spacing: 0.9px; font-family: Arial, sans-serif; }
+        .wave { fill: none; stroke: rgba(22, 101, 52, 0.24); stroke-width: 0.9; }
+        .alt { fill: none; stroke: rgba(14, 116, 144, 0.18); stroke-width: 0.65; }
+        .micro { fill: rgba(22, 101, 52, 0.22); font-size: 7px; letter-spacing: 1.05px; font-family: Arial, sans-serif; }
+        .label-band { fill: rgba(255, 255, 255, 0.58); stroke: rgba(22, 101, 52, 0.24); stroke-width: 1; }
+        .visible-label { fill: rgba(11, 89, 53, 0.34); font-size: 18px; font-weight: 700; letter-spacing: 1.8px; font-family: Arial, sans-serif; }
       </style>
     </defs>
     <rect width="100%" height="100%" fill="white" fill-opacity="0" />
     <g class="wave">${lines.join('')}</g>
+    ${visibleBands}
     ${hiddenText}
   </svg>`;
 
@@ -77,6 +90,7 @@ export function buildSecurePatternLayer(options: SecurePatternOptions): SecurePa
     enabled: true,
     microtext,
     backgroundImage: encodeSvg(svg),
-    style: `background-image:url("${encodeSvg(svg)}");background-repeat:repeat;background-size:680px 920px;opacity:0.16;`,
+    visibleLabel,
+    style: `background-image:url("${encodeSvg(svg)}");background-repeat:repeat;background-size:680px 920px;opacity:0.32;`,
   };
 }

--- a/src/pages/AdminScorelistsPage.tsx
+++ b/src/pages/AdminScorelistsPage.tsx
@@ -286,7 +286,7 @@ const AdminScorelistsPage = () => {
 <style>body{font-family:Arial,sans-serif;margin:40px;color:#1a1a1a;position:relative;background:#fff}h1{text-align:center;color:#1e6b3a}h2{color:#1e6b3a;border-bottom:2px solid #1e6b3a;padding-bottom:4px}
 table{width:100%;border-collapse:collapse;margin:10px 0}th,td{border:1px solid #ddd;padding:6px 8px;font-size:12px}th{background:#f0f7f0;text-align:left}
 .scoreboard{display:flex;justify-content:space-around;text-align:center;background:#f0f7f0;padding:20px;border-radius:8px;margin:20px 0}
-.team-score{font-size:28px;font-weight:bold;color:#1e6b3a}.watermark{position:fixed;top:40%;left:10%;transform:rotate(-30deg);font-size:80px;color:rgba(30,107,58,0.04);white-space:nowrap;pointer-events:none;z-index:-1}.secure-pattern{position:fixed;inset:0;pointer-events:none;z-index:-3}
+.team-score{font-size:28px;font-weight:bold;color:#1e6b3a}.watermark{position:fixed;top:40%;left:10%;transform:rotate(-30deg);font-size:80px;color:rgba(30,107,58,0.04);white-space:nowrap;pointer-events:none;z-index:-1}.secure-pattern{position:fixed;inset:0;pointer-events:none;z-index:-3}.secure-pattern-notice{margin:10px 0 18px;padding:10px 14px;border:1px dashed #7ab28d;border-radius:10px;background:rgba(232,245,233,0.92);color:#145c36;font-size:11px;font-weight:700;letter-spacing:0.08em;text-align:center;text-transform:uppercase}
 .footer{text-align:center;font-size:9px;color:#999;margin-top:30px;border-top:1px solid #ddd;padding-top:10px}
 .certified{background:#e8f5e9;border:2px solid #1e6b3a;text-align:center;padding:12px;border-radius:8px;font-weight:bold;color:#1e6b3a;margin:20px 0}
 .match-book-page{page-break-before:always}
@@ -307,6 +307,7 @@ ${securePattern.enabled ? `<div class="secure-pattern" style="${securePattern.st
 <p style="text-align:center;font-size:10px;text-transform:uppercase;letter-spacing:3px;color:#666">Cricket Club Portal</p>
 <h1 class="intaglio">Digital ${sl.scope_type === 'match' ? 'Match' : 'Tournament'} Scorelist</h1>
 <p style="text-align:center;font-family:monospace;font-size:11px;color:#999">${sl.scorelist_id}</p>
+${securePattern.enabled ? `<div class="secure-pattern-notice">Visible anti-copy background active • ${securePattern.visibleLabel}</div>` : ''}
 <p style="text-align:center"><span class="status-chip intaglio">${detailedStatus}${effectiveLocked ? ' • LOCKED' : ''}</span></p>
 <div class="verification-panel">
   <div class="verification-copy">


### PR DESCRIPTION
### Motivation
- The secure-pattern background used for exported scorelist PDFs was intentionally very subtle (small microtext, low opacity) and was hard to spot by eye, so reviewers couldn't tell the anti-copy layer was present.
- Increase human-visible presence of the security layer while preserving the hidden microtext layer for verification and anti-copying purposes.

### Description
- Enhanced the reusable pattern generator in `src/lib/scorelistSecurePattern.ts` to add a `visibleLabel`, denser/larger microtext, stronger wave stroke contrast, repeated diagonal visible bands showing `SECURE PATTERN • MATCH-{matchId}-{checksum}-{timestamp}`, and increased background opacity.
- Returned object from the builder now includes `visibleLabel` and a higher-opacity `style` so the pattern is noticeable in the rendered HTML/PDF background.
- Integrated a visual notice in the scorelist export HTML in `src/pages/AdminScorelistsPage.tsx` by adding a `.secure-pattern-notice` style and rendering a banner under the scorelist ID when the secure pattern is enabled.

### Testing
- Ran `npm run build` which failed in this environment because the local `vite` binary is not available (dependencies not installed). 
- Ran `npm run test` which failed because the local `vitest` binary is not available (dependencies not installed). 
- Ran `npm ci` which could not complete due to registry access returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1ee9fc70832cb6aeb9fba4e358d4)