### PR TITLE
Restrict schedule approval actions to eligible approvers and add Management schedule approvals view

### DIFF
--- a/src/components/admin/AdminGovernance.tsx
+++ b/src/components/admin/AdminGovernance.tsx
@@ -51,7 +51,7 @@ export function AdminGovernance() {
     toast({ title: 'Schedule version created', description: 'A new draft version has been saved without overwriting prior versions.' });
   };
 
-  const pendingSchedules = schedules.filter((item) => item.status === 'draft' || item.status === 'pending_approval');
+  const visibleSchedules = [...schedules].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
   return (
     <div className="space-y-6">
@@ -101,7 +101,7 @@ export function AdminGovernance() {
       <Card>
         <CardHeader><CardTitle>Approval roadmap for tournament schedules</CardTitle></CardHeader>
         <CardContent className="space-y-4">
-          {pendingSchedules.map((schedule) => {
+          {visibleSchedules.map((schedule) => {
             const scheduleApprovals = approvals.filter((item) => item.schedule_id === schedule.schedule_id);
             const previous = schedules.find((item) => item.schedule_id === schedule.parent_schedule_id);
             const diff = scheduleService.diffVersions(previous, schedule);
@@ -131,13 +131,15 @@ export function AdminGovernance() {
                   <p className="text-sm font-medium">Approval roadmap</p>
                   <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
                     {roadmap.map((step) => (
-                      <div key={step.role} className={`rounded-lg border p-3 ${step.completed ? 'border-primary/30 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
+                      <div key={step.role} className={`rounded-lg border p-3 ${step.approval?.decision === 'rejected' ? 'border-destructive/30 bg-destructive/5' : step.completed ? 'border-primary/30 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
                         <div className="flex items-center justify-between gap-2">
                           <p className="font-medium">{step.role}</p>
-                          <Badge variant={step.completed ? 'default' : 'secondary'}>{step.completed ? 'Approved' : `Pending with ${step.role}`}</Badge>
+                          <Badge variant={step.approval?.decision === 'rejected' ? 'destructive' : step.completed ? 'default' : 'secondary'}>
+                            {step.approval?.decision === 'rejected' ? 'Rejected' : step.completed ? 'Approved' : `Pending with ${step.role}`}
+                          </Badge>
                         </div>
                         <p className="mt-2 text-xs text-muted-foreground">
-                          {step.approval ? `${step.approval.approver_name} • ${new Date(step.approval.timestamp).toLocaleString()}` : 'Waiting for this office bearer approval.'}
+                          {step.approval ? `${step.approval.approver_name} • ${new Date(step.approval.timestamp).toLocaleString()}${step.approval.comments ? ` • ${step.approval.comments}` : ''}` : 'Waiting for this office bearer approval.'}
                         </p>
                       </div>
                     ))}
@@ -154,14 +156,16 @@ export function AdminGovernance() {
                   {diff.length === 0 && <p className="text-sm text-muted-foreground">No previous version for comparison.</p>}
                 </div>
 
-                <div className="flex gap-2 flex-wrap">
-                  <Button size="sm" variant="outline" onClick={async () => { await scheduleService.submitForApproval(schedule.schedule_id, user!); setRefreshKey((value) => value + 1); }}>Send for Approval</Button>
-                </div>
+                {schedule.status === 'draft' && (
+                  <div className="flex gap-2 flex-wrap">
+                    <Button size="sm" variant="outline" onClick={async () => { await scheduleService.submitForApproval(schedule.schedule_id, user!); setRefreshKey((value) => value + 1); }}>Send for Approval</Button>
+                  </div>
+                )}
                 <div className="text-sm text-muted-foreground">Approvals received: {scheduleApprovals.map((item) => `${item.approver_name} (${item.approver_role})`).join(', ') || 'None yet'}</div>
               </div>
             );
           })}
-          {pendingSchedules.length === 0 && <p className="text-sm text-muted-foreground">No draft or pending schedules to review.</p>}
+          {visibleSchedules.length === 0 && <p className="text-sm text-muted-foreground">No schedule versions available yet.</p>}
         </CardContent>
       </Card>
     </div>

--- a/src/lib/workflowStatus.ts
+++ b/src/lib/workflowStatus.ts
@@ -143,16 +143,21 @@ export function getScorelistDetailedStatus(scorelist: DigitalScorelist, manageme
 }
 
 export function getScheduleApprovalRoadmap(schedule: ScheduleRecord, approvals: ScheduleApprovalRecord[]) {
-  const approvedByRole = new Map(
-    approvals
-      .filter((item) => item.schedule_id === schedule.schedule_id && item.decision === 'approved')
-      .map((item) => [item.approver_role, item]),
-  );
+  const latestDecisionByRole = new Map<string, ScheduleApprovalRecord>();
+
+  approvals
+    .filter((item) => item.schedule_id === schedule.schedule_id)
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    .forEach((item) => {
+      if (!latestDecisionByRole.has(item.approver_role)) {
+        latestDecisionByRole.set(item.approver_role, item);
+      }
+    });
 
   return scheduleApproverRoles.map((role) => ({
     role,
-    approval: approvedByRole.get(role),
-    completed: approvedByRole.has(role),
+    approval: latestDecisionByRole.get(role),
+    completed: latestDecisionByRole.get(role)?.decision === 'approved',
   }));
 }
 

--- a/src/pages/ManagementPage.tsx
+++ b/src/pages/ManagementPage.tsx
@@ -14,7 +14,7 @@ import { User, Shield, ShieldCheck, Clock, CheckCircle2, ChevronDown, ChevronUp,
 import { format } from 'date-fns';
 import { v2api, logAudit, istNow } from '@/lib/v2api';
 import { ManagementUser, DigitalScorelist, CertificationApproval } from '@/lib/v2types';
-import { getScorelistDetailedStatus, getScorelistRoadmap, resolveStageFromDesignation, scorelistStageLabels, scorelistStageOrder } from '@/lib/workflowStatus';
+import { getScheduleApprovalRoadmap, getScheduleDetailedStatus, getScorelistDetailedStatus, getScorelistRoadmap, resolveStageFromDesignation, scorelistStageLabels, scorelistStageOrder } from '@/lib/workflowStatus';
 import { useToast } from '@/hooks/use-toast';
 import { Navigate, Link } from 'react-router-dom';
 import { useData } from '@/lib/DataContext';
@@ -22,6 +22,9 @@ import { generateId } from '@/lib/utils';
 import { getAdminNotificationRecipient, sendScorelistApprovalRequestBulk, sendSystemEmail, sendApprovalThankYouEmail, sendScorelistStatusEmailToAdmin, sendMessageNotificationEmail, sendScorelistReminderEmail } from '@/lib/mailer';
 import { DataIntegrityBadge, SecurityShieldBadge, SessionFingerprint } from '@/components/SecurityBadge';
 import { PageLoader } from '@/components/LoadingOverlay';
+import { scheduleService } from '@/schedules/scheduleService';
+import { getActorId, isScheduleApproverRole } from '@/lib/accessControl';
+import { ScheduleRecord } from '@/schedules/types';
 
 const stageOrder = [...scorelistStageOrder];
 const stageLabels: Record<string, string> = scorelistStageLabels;
@@ -44,9 +47,11 @@ const ManagementPage = () => {
   const [reviewComment, setReviewComment] = useState('');
   const [reviewingScorelist, setReviewingScorelist] = useState<DigitalScorelist | null>(null);
   const [scorelistActionLoading, setScorelistActionLoading] = useState(false);
+  const [scheduleActionLoadingId, setScheduleActionLoadingId] = useState<string | null>(null);
+  const [scheduleComments, setScheduleComments] = useState<Record<string, string>>({});
 
   const refresh = async () => {
-    const [users, scorelistData] = await Promise.all([v2api.getManagementUsers(), v2api.getScorelists()]);
+    const [users, scorelistData] = await Promise.all([v2api.getManagementUsers(), v2api.getScorelists(), scheduleService.syncFromBackend()]);
     setMgmtUsers(users.filter(m => String(m.status || '').trim().toLowerCase() !== 'inactive'));
     setScorelists(scorelistData);
     setLoading(false);
@@ -76,6 +81,30 @@ const ManagementPage = () => {
     const nextStage = currentIdx < stageOrder.length - 1 ? stageOrder[currentIdx + 1] : null;
     return nextStage === userStage;
   }), [isManagement, scorelists, user?.designation, user?.management_id]);
+  const scheduleApprover = isManagement && isScheduleApproverRole(user?.designation);
+  const pendingSchedules = useMemo(() => {
+    if (!scheduleApprover || !user) return [] as ScheduleRecord[];
+    return scheduleService.getSchedules().filter((schedule) => {
+      if (schedule.status !== 'pending_approval') return false;
+      const approvals = scheduleService.getApprovals().filter((item) => item.schedule_id === schedule.schedule_id);
+      return !approvals.some((item) => item.approver_id === getActorId(user));
+    });
+  }, [scheduleApprover, user, loading, scheduleActionLoadingId]);
+
+  const reviewSchedule = async (scheduleId: string, decision: 'approved' | 'rejected') => {
+    if (!user) return;
+    setScheduleActionLoadingId(scheduleId);
+    try {
+      if (decision === 'approved') await scheduleService.approveSchedule(scheduleId, scheduleComments[scheduleId] || '', user);
+      else await scheduleService.rejectSchedule(scheduleId, scheduleComments[scheduleId] || '', user);
+      toast({ title: decision === 'approved' ? 'Schedule approved' : 'Schedule rejected', description: decision === 'approved' ? 'Your schedule approval has been recorded.' : 'The schedule was returned for revision.' });
+      await refresh();
+    } catch (error) {
+      toast({ title: 'Schedule action failed', description: error instanceof Error ? error.message : 'Unexpected error', variant: 'destructive' });
+    } finally {
+      setScheduleActionLoadingId(null);
+    }
+  };
 
   useEffect(() => {
     if (!isManagement || !user?.management_id) return;
@@ -317,6 +346,7 @@ const ManagementPage = () => {
                 {pendingScorelists.length > 0 && <Badge className="bg-destructive text-destructive-foreground text-[10px] h-4 px-1">{pendingScorelists.length}</Badge>}
               </TabsTrigger>
               <TabsTrigger value="all" className="text-xs md:text-sm gap-1"><Shield className="h-3 w-3" /> All Scorelists</TabsTrigger>
+              {scheduleApprover && <TabsTrigger value="schedule-approvals" className="text-xs md:text-sm gap-1"><Clock className="h-3 w-3" /> Schedule Approvals {pendingSchedules.length > 0 && <Badge className="bg-destructive text-destructive-foreground text-[10px] h-4 px-1">{pendingSchedules.length}</Badge>}</TabsTrigger>}
               <TabsTrigger value="messages" className="text-xs md:text-sm gap-1"><MessageSquare className="h-3 w-3" /> Messages</TabsTrigger>
               <TabsTrigger value="compose" className="text-xs md:text-sm gap-1"><Send className="h-3 w-3" /> Send Notice</TabsTrigger>
             </TabsList>
@@ -415,6 +445,79 @@ const ManagementPage = () => {
                 })}
               </div>
             </TabsContent>
+
+            {scheduleApprover && (
+              <TabsContent value="schedule-approvals" className="mt-4 space-y-3">
+                {pendingSchedules.length === 0 && (
+                  <Card><CardContent className="p-6 text-center text-muted-foreground">No schedules are waiting for your approval right now.</CardContent></Card>
+                )}
+                {pendingSchedules.map((schedule) => {
+                  const approvals = scheduleService.getApprovals().filter((item) => item.schedule_id === schedule.schedule_id);
+                  const roadmap = getScheduleApprovalRoadmap(schedule, approvals);
+                  const previous = scheduleService.getSchedules().find((item) => item.schedule_id === schedule.parent_schedule_id);
+                  const diff = scheduleService.diffVersions(previous, schedule);
+                  return (
+                    <Card key={schedule.schedule_id} className="border-l-4 border-l-primary/50">
+                      <CardContent className="p-4 space-y-4">
+                        <div className="flex items-start justify-between gap-3 flex-wrap">
+                          <div>
+                            <p className="font-display font-bold">{schedule.tournament_name} · Version {schedule.version_number}</p>
+                            <p className="text-sm text-muted-foreground">{getScheduleDetailedStatus(schedule, approvals)}</p>
+                            <p className="text-xs text-muted-foreground mt-1">Submitted on {new Date(schedule.timestamp).toLocaleString()}</p>
+                          </div>
+                          <Badge variant="outline">Hash {schedule.hash.slice(0, 12)}…</Badge>
+                        </div>
+
+                        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                          {roadmap.map((step) => (
+                            <div key={step.role} className={`rounded-lg border p-3 text-sm ${step.approval?.decision === 'rejected' ? 'border-destructive/30 bg-destructive/5' : step.completed ? 'border-primary/20 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
+                              <div className="flex items-center justify-between gap-2">
+                                <p className="font-medium">{step.role}</p>
+                                <Badge variant={step.approval?.decision === 'rejected' ? 'destructive' : step.completed ? 'default' : 'secondary'}>
+                                  {step.approval?.decision === 'rejected' ? 'Rejected' : step.completed ? 'Approved' : 'Pending'}
+                                </Badge>
+                              </div>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {step.approval ? `${step.approval.approver_name} • ${new Date(step.approval.timestamp).toLocaleString()}` : 'Awaiting action from this approver.'}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+
+                        <div className="rounded-lg border bg-muted/20 p-3 text-sm space-y-1">
+                          <p><strong>Change log:</strong> {schedule.change_log || '—'}</p>
+                          {schedule.rejection_reason && <p><strong>Revision note:</strong> {schedule.rejection_reason}</p>}
+                        </div>
+
+                        <div className="space-y-2">
+                          <p className="text-sm font-medium">Diff against previous version</p>
+                          {diff.length === 0 && <p className="text-sm text-muted-foreground">Baseline version.</p>}
+                          {diff.map((entry) => (
+                            <div key={entry.match_id} className={`rounded border p-2 text-sm ${entry.kind === 'added' ? 'bg-green-500/10 border-green-500/30' : entry.kind === 'updated' ? 'bg-yellow-500/10 border-yellow-500/30' : 'bg-red-500/10 border-red-500/30'}`}>
+                              {entry.kind.toUpperCase()} · {entry.current?.team_a || entry.previous?.team_a} vs {entry.current?.team_b || entry.previous?.team_b}
+                            </div>
+                          ))}
+                        </div>
+
+                        <Textarea
+                          placeholder="Approval or rejection note"
+                          value={scheduleComments[schedule.schedule_id] || ''}
+                          onChange={(e) => setScheduleComments((prev) => ({ ...prev, [schedule.schedule_id]: e.target.value }))}
+                        />
+                        <div className="flex gap-2 flex-wrap">
+                          <Button loading={scheduleActionLoadingId === schedule.schedule_id} loadingText="Approving..." onClick={() => reviewSchedule(schedule.schedule_id, 'approved')}>
+                            Approve
+                          </Button>
+                          <Button variant="destructive" loading={scheduleActionLoadingId === schedule.schedule_id} loadingText="Rejecting..." onClick={() => reviewSchedule(schedule.schedule_id, 'rejected')}>
+                            Reject
+                          </Button>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </TabsContent>
+            )}
 
             <TabsContent value="messages" className="mt-4 space-y-3">
               <h3 className="font-display text-lg font-bold flex items-center gap-2"><MessageSquare className="h-5 w-5 text-primary" /> Messages</h3>

--- a/src/tournaments/TournamentsHubPage.tsx
+++ b/src/tournaments/TournamentsHubPage.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/lib/auth';
-import { canApproveTournamentRegistration, canManageTournament, getActorId, getActorName } from '@/lib/accessControl';
+import { canApproveSchedule, canApproveTournamentRegistration, canManageTournament, getActorId, getActorName } from '@/lib/accessControl';
 import { useToast } from '@/hooks/use-toast';
 import { tournamentService } from './tournamentService';
 import { scheduleService } from '@/schedules/scheduleService';
@@ -17,6 +17,7 @@ import { ScheduleMatch } from '@/schedules/types';
 import { useData } from '@/lib/DataContext';
 import { normalizeId } from '@/lib/dataUtils';
 import { RegistrationRecord, TournamentRegistryRecord } from './types';
+import { getScheduleApprovalRoadmap, getScheduleDetailedStatus } from '@/lib/workflowStatus';
 
 const emptyScheduleRow: ScheduleMatch = { match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' };
 const emptyTournamentForm = { name: '', format: 'T20', venue: '', start_date: '', end_date: '', registration_deadline: '', notes: '', season_year: String(new Date().getFullYear()) };
@@ -111,6 +112,7 @@ const TournamentsHubPage = () => {
   const linkedRecord = activeTarget?.registryRecord;
 
   const linkedSeasonCandidates = existingSeasonOptions.filter((item) => !item.registryRecord);
+  const canCurrentUserApproveSchedules = canApproveSchedule(user);
 
   const createTournament = async () => {
     if (!user || !canManageTournament(user)) return;
@@ -532,6 +534,9 @@ const TournamentsHubPage = () => {
                 const previous = scheduleService.getSchedules().find((item) => item.schedule_id === schedule.parent_schedule_id);
                 const diff = scheduleService.diffVersions(previous, schedule);
                 const approvals = scheduleService.getApprovals().filter((item) => item.schedule_id === schedule.schedule_id);
+                const roadmap = getScheduleApprovalRoadmap(schedule, approvals);
+                const hasCurrentUserDecision = approvals.some((item) => item.approver_id === getActorId(user));
+                const canReviewSchedule = canCurrentUserApproveSchedules && schedule.status === 'pending_approval' && !hasCurrentUserDecision;
                 return (
                   <div key={schedule.schedule_id} className="rounded-lg border p-4 space-y-3">
                     <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -545,6 +550,24 @@ const TournamentsHubPage = () => {
                       </div>
                     </div>
                     <p className="text-sm"><strong>Change log:</strong> {schedule.change_log || '—'}</p>
+                    <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
+                      <p className="text-sm"><strong>Status:</strong> {getScheduleDetailedStatus(schedule, approvals)}</p>
+                      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                        {roadmap.map((step) => (
+                          <div key={step.role} className={`rounded border p-2 text-sm ${step.approval?.decision === 'rejected' ? 'border-destructive/30 bg-destructive/5' : step.completed ? 'border-primary/20 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="font-medium">{step.role}</p>
+                              <Badge variant={step.approval?.decision === 'rejected' ? 'destructive' : step.completed ? 'default' : 'secondary'}>
+                                {step.approval?.decision === 'rejected' ? 'Rejected' : step.completed ? 'Approved' : 'Pending'}
+                              </Badge>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {step.approval ? `${step.approval.approver_name} • ${new Date(step.approval.timestamp).toLocaleString()}` : 'Awaiting action from this approver.'}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
                     <div className="space-y-2">
                       {diff.map((entry) => (
                         <div key={entry.match_id} className={`rounded border p-2 text-sm ${entry.kind === 'added' ? 'bg-green-500/10 border-green-500/30' : entry.kind === 'updated' ? 'bg-yellow-500/10 border-yellow-500/30' : 'bg-red-500/10 border-red-500/30'}`}>
@@ -554,12 +577,14 @@ const TournamentsHubPage = () => {
                       {diff.length === 0 && <p className="text-sm text-muted-foreground">Baseline version.</p>}
                     </div>
                     <p className="text-sm text-muted-foreground">Approvals: {approvals.filter((item) => item.decision === 'approved').map((item) => `${item.approver_name} (${item.approver_role})`).join(', ') || 'Pending'}</p>
-                    <Textarea placeholder="Approval or rejection note" value={approvalComments[schedule.schedule_id] || ''} onChange={(e) => setApprovalComments((prev) => ({ ...prev, [schedule.schedule_id]: e.target.value }))} />
+                    {canReviewSchedule && (
+                      <Textarea placeholder="Approval or rejection note" value={approvalComments[schedule.schedule_id] || ''} onChange={(e) => setApprovalComments((prev) => ({ ...prev, [schedule.schedule_id]: e.target.value }))} />
+                    )}
                     <div className="flex gap-2 flex-wrap">
                       {canManageTournament(user) && schedule.status === 'draft' && <Button variant="outline" onClick={() => submitScheduleForApproval(schedule.schedule_id)}>Send for Approval</Button>}
                       <Button variant="outline" onClick={() => scheduleService.downloadPdf(schedule.schedule_id)} disabled={schedule.status !== 'approved'}>PDF</Button>
-                      <Button onClick={() => decideSchedule(schedule.schedule_id, 'approved')} disabled={schedule.status !== 'pending_approval'}>Approve</Button>
-                      <Button variant="destructive" onClick={() => decideSchedule(schedule.schedule_id, 'rejected')} disabled={schedule.status !== 'pending_approval'}>Reject</Button>
+                      {canReviewSchedule && <Button onClick={() => decideSchedule(schedule.schedule_id, 'approved')}>Approve</Button>}
+                      {canReviewSchedule && <Button variant="destructive" onClick={() => decideSchedule(schedule.schedule_id, 'rejected')}>Reject</Button>}
                     </div>
                   </div>
                 );


### PR DESCRIPTION
### Motivation
- Prevent approval controls (Approve/Reject, approval note) from being visible to all users on tournament pages and show them only to eligible schedule approvers who have not already acted.
- Provide management approvers with a dedicated workspace to review and sign schedule approvals from the Management dashboard.
- Ensure admins can view the full approval roadmap and per-role status (including rejected decisions and comments) for schedule versions.

### Description
- Update schedule roadmap logic in `src/lib/workflowStatus.ts` to consider the latest decision per approver role so UI can display approved/rejected/pending correctly (`getScheduleApprovalRoadmap`).
- Restrict schedule approval UI in `src/tournaments/TournamentsHubPage.tsx` so the approval note field and `Approve`/`Reject` buttons render only when `canApproveSchedule(user)` is true, the schedule is `pending_approval`, and the current approver hasn't already acted, and add per-role roadmap/status display for each schedule version.
- Expand admin governance view in `src/components/admin/AdminGovernance.tsx` to list all schedule versions (not just draft/pending) and show each role’s roadmap, including rejected decisions and comments.
- Add schedule-approvals functionality to `src/pages/ManagementPage.tsx` (new tab) so schedule approvers can see pending schedule versions, add comments, and approve/reject from their dashboard, and wire schedule backend sync into the management refresh flow.

### Testing
- Ran `git diff --check` successfully with no reported whitespace errors.
- Ran `npm test -- --runInBand`, which failed in this environment because `vitest` is not available (test runner not installed here).
- Attempted `npm run build` which failed in this environment because `vite` is not available.
- Attempted `npm install` but dependency installation failed with a registry `403 Forbidden`, so full dependency-based test/build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be258aa008832c91276432c18a384e)