### PR TITLE
Fix scorelist verification, tournament registration/election visibility, and schedule approval UI

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -30,7 +30,7 @@ export function Navbar() {
           </Button>
         )}
 
-        {user && (
+        {user && user.type !== 'management' && (
           <>
             <Button variant="ghost" size="sm" asChild onClick={close}>
               <Link to="/elections"><Vote className="h-4 w-4 mr-1" /> Elections</Link>

--- a/src/components/admin/AdminGovernance.tsx
+++ b/src/components/admin/AdminGovernance.tsx
@@ -13,6 +13,7 @@ import { tournamentService } from '@/tournaments/tournamentService';
 import { useToast } from '@/hooks/use-toast';
 import { getScheduleApprovalRoadmap, getScheduleDetailedStatus } from '@/lib/workflowStatus';
 import { formatInIST } from '@/lib/time';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 const initialMatch = (): ScheduleMatch => ({ match_id: '', date: '', time: '', venue: '', team_a: '', team_b: '', stage: 'League', notes: '' });
 
@@ -24,6 +25,7 @@ export function AdminGovernance() {
   const [tournamentName, setTournamentName] = useState('');
   const [changeLog, setChangeLog] = useState('');
   const [matches, setMatches] = useState<ScheduleMatch[]>([initialMatch()]);
+  const [expandedSchedules, setExpandedSchedules] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     Promise.all([electionService.syncFromBackend(), scheduleService.syncFromBackend(), tournamentService.syncFromBackend()]).finally(() => setRefreshKey((value) => value + 1));
@@ -52,7 +54,15 @@ export function AdminGovernance() {
     toast({ title: 'Schedule version created', description: 'A new draft version has been saved without overwriting prior versions.' });
   };
 
-  const visibleSchedules = [...schedules].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  const visibleSchedules = useMemo(() => {
+    const latestByTournament = new Map<string, typeof schedules[number]>();
+    [...schedules]
+      .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+      .forEach((schedule) => {
+        if (!latestByTournament.has(schedule.tournament_id)) latestByTournament.set(schedule.tournament_id, schedule);
+      });
+    return [...latestByTournament.values()];
+  }, [schedules]);
 
   return (
     <div className="space-y-6">
@@ -100,7 +110,10 @@ export function AdminGovernance() {
       </Card>
 
       <Card>
-        <CardHeader><CardTitle>Approval roadmap for tournament schedules</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>Approval roadmap for tournament schedules</CardTitle>
+          <p className="text-sm text-muted-foreground">Showing only the latest active schedule per tournament. Expand a card to inspect the roadmap and version diff.</p>
+        </CardHeader>
         <CardContent className="space-y-4">
           {visibleSchedules.map((schedule) => {
             const scheduleApprovals = approvals.filter((item) => item.schedule_id === schedule.schedule_id);
@@ -108,6 +121,7 @@ export function AdminGovernance() {
             const diff = scheduleService.diffVersions(previous, schedule);
             const roadmap = getScheduleApprovalRoadmap(schedule, approvals);
             const detailedStatus = getScheduleDetailedStatus(schedule, approvals);
+            const isExpanded = expandedSchedules[schedule.schedule_id] ?? false;
 
             return (
               <div key={schedule.schedule_id} className="rounded-lg border p-4 space-y-4">
@@ -119,50 +133,57 @@ export function AdminGovernance() {
                   <div className="flex gap-2 flex-wrap">
                     <Badge>{detailedStatus}</Badge>
                     <Badge variant="outline">Hash {schedule.hash.slice(0, 10)}…</Badge>
+                    <Button size="sm" variant="outline" onClick={() => setExpandedSchedules((prev) => ({ ...prev, [schedule.schedule_id]: !isExpanded }))}>
+                      {isExpanded ? <>Hide details <ChevronUp className="ml-1 h-4 w-4" /></> : <>Show details <ChevronDown className="ml-1 h-4 w-4" /></>}
+                    </Button>
                   </div>
                 </div>
 
-                <div className="rounded-lg border bg-muted/30 p-3 text-sm space-y-1">
-                  <p><strong>Current status:</strong> {detailedStatus}</p>
-                  <p><strong>Change log:</strong> {schedule.change_log || 'No change log'}</p>
-                  {schedule.rejection_reason && <p><strong>Revision note:</strong> {schedule.rejection_reason}</p>}
-                </div>
-
-                <div className="space-y-2">
-                  <p className="text-sm font-medium">Approval roadmap</p>
-                  <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-                    {roadmap.map((step) => (
-                      <div key={step.role} className={`rounded-lg border p-3 ${step.approval?.decision === 'rejected' ? 'border-destructive/30 bg-destructive/5' : step.completed ? 'border-primary/30 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
-                        <div className="flex items-center justify-between gap-2">
-                          <p className="font-medium">{step.role}</p>
-                          <Badge variant={step.approval?.decision === 'rejected' ? 'destructive' : step.completed ? 'default' : 'secondary'}>
-                            {step.approval?.decision === 'rejected' ? 'Rejected' : step.completed ? 'Approved' : `Pending with ${step.role}`}
-                          </Badge>
-                        </div>
-                        <p className="mt-2 text-xs text-muted-foreground">
-                          {step.approval ? `${step.approval.approver_name} • ${formatInIST(step.approval.timestamp)}${step.approval.comments ? ` • ${step.approval.comments}` : ''}` : 'Waiting for this office bearer approval.'}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <p className="text-sm font-medium">Diff against previous version</p>
-                  {diff.map((entry) => (
-                    <div key={entry.match_id} className={`rounded border p-2 text-sm ${entry.kind === 'added' ? 'bg-green-500/10 border-green-500/30' : entry.kind === 'updated' ? 'bg-yellow-500/10 border-yellow-500/30' : 'bg-red-500/10 border-red-500/30'}`}>
-                      <strong>{entry.kind.toUpperCase()}</strong> · {entry.current?.team_a || entry.previous?.team_a} vs {entry.current?.team_b || entry.previous?.team_b}
+                {isExpanded && (
+                  <>
+                    <div className="rounded-lg border bg-muted/30 p-3 text-sm space-y-1">
+                      <p><strong>Current status:</strong> {detailedStatus}</p>
+                      <p><strong>Change log:</strong> {schedule.change_log || 'No change log'}</p>
+                      {schedule.rejection_reason && <p><strong>Revision note:</strong> {schedule.rejection_reason}</p>}
                     </div>
-                  ))}
-                  {diff.length === 0 && <p className="text-sm text-muted-foreground">No previous version for comparison.</p>}
-                </div>
 
-                {schedule.status === 'draft' && (
-                  <div className="flex gap-2 flex-wrap">
-                    <Button size="sm" variant="outline" onClick={async () => { await scheduleService.submitForApproval(schedule.schedule_id, user!); setRefreshKey((value) => value + 1); }}>Send for Approval</Button>
-                  </div>
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Approval roadmap</p>
+                      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                        {roadmap.map((step) => (
+                          <div key={step.role} className={`rounded-lg border p-3 ${step.approval?.decision === 'rejected' ? 'border-destructive/30 bg-destructive/5' : step.completed ? 'border-primary/30 bg-primary/5' : 'border-amber-500/30 bg-amber-500/5'}`}>
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="font-medium">{step.role}</p>
+                              <Badge variant={step.approval?.decision === 'rejected' ? 'destructive' : step.completed ? 'default' : 'secondary'}>
+                                {step.approval?.decision === 'rejected' ? 'Rejected' : step.completed ? 'Approved' : `Pending with ${step.role}`}
+                              </Badge>
+                            </div>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              {step.approval ? `${step.approval.approver_name} • ${formatInIST(step.approval.timestamp)}${step.approval.comments ? ` • ${step.approval.comments}` : ''}` : 'Waiting for this office bearer approval.'}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Diff against previous version</p>
+                      {diff.map((entry) => (
+                        <div key={entry.match_id} className={`rounded border p-2 text-sm ${entry.kind === 'added' ? 'bg-green-500/10 border-green-500/30' : entry.kind === 'updated' ? 'bg-yellow-500/10 border-yellow-500/30' : 'bg-red-500/10 border-red-500/30'}`}>
+                          <strong>{entry.kind.toUpperCase()}</strong> · {entry.current?.team_a || entry.previous?.team_a} vs {entry.current?.team_b || entry.previous?.team_b}
+                        </div>
+                      ))}
+                      {diff.length === 0 && <p className="text-sm text-muted-foreground">No previous version for comparison.</p>}
+                    </div>
+
+                    {schedule.status === 'draft' && (
+                      <div className="flex gap-2 flex-wrap">
+                        <Button size="sm" variant="outline" onClick={async () => { await scheduleService.submitForApproval(schedule.schedule_id, user!); setRefreshKey((value) => value + 1); }}>Send for Approval</Button>
+                      </div>
+                    )}
+                    <div className="text-sm text-muted-foreground">Approvals received: {scheduleApprovals.map((item) => `${item.approver_name} (${item.approver_role})`).join(', ') || 'None yet'}</div>
+                  </>
                 )}
-                <div className="text-sm text-muted-foreground">Approvals received: {scheduleApprovals.map((item) => `${item.approver_name} (${item.approver_role})`).join(', ') || 'None yet'}</div>
               </div>
             );
           })}

--- a/src/elections/ElectionsPage.tsx
+++ b/src/elections/ElectionsPage.tsx
@@ -46,8 +46,6 @@ const ElectionsPage = () => {
     electionService.syncFromBackend().finally(() => setRefreshKey((value) => value + 1));
   }, []);
 
-  if (!user) return <Navigate to="/login" replace />;
-
   const elections = useMemo(() => electionService.getElections(), [refreshKey]);
   const nominations = useMemo(() => electionService.getNominations(), [refreshKey]);
   const terms = useMemo(() => electionService.getTerms(), [refreshKey]);
@@ -137,11 +135,14 @@ const ElectionsPage = () => {
     }
   };
 
-  const participationNotice = user.type === 'player'
+  const participationNotice = user?.type === 'player'
     ? 'Players can submit nominations, wait for admin approval, and vote in open elections.'
-    : user.type === 'admin'
+    : user?.type === 'admin'
       ? 'Admin can create elections, approve or reject nominations, view vote results, and publish final results.'
       : 'Management accounts cannot submit nominations or participate in player-only elections.';
+
+  if (!user) return <Navigate to="/login" replace />;
+  if (user.type === 'management') return <Navigate to="/management" replace />;
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/lib/accessControl.ts
+++ b/src/lib/accessControl.ts
@@ -51,7 +51,7 @@ export function canManageTournament(user: AuthUser | null | undefined) {
 }
 
 export function canApproveTournamentRegistration(user: AuthUser | null | undefined) {
-  return user?.type === 'management' && user.designation === MANAGEMENT_DESIGNATIONS.TOURNAMENT_DIRECTOR;
+  return user?.type === 'admin' || (user?.type === 'management' && user.designation === MANAGEMENT_DESIGNATIONS.TOURNAMENT_DIRECTOR);
 }
 
 export function canApproveSchedule(user: AuthUser | null | undefined) {

--- a/src/pages/AdminScorelistsPage.tsx
+++ b/src/pages/AdminScorelistsPage.tsx
@@ -362,16 +362,8 @@ ${effectiveLocked ? '<div class="certified">✔ OFFICIALLY CERTIFIED MATCH RESUL
       stage,
     });
     const locked = stage === 'official_certified';
-    const payload = safeParsePayload(sl) || {};
-    payload.__certification = {
-      status: stage,
-      locked,
-      approvals: certs,
-      lastUpdatedAt: new Date().toISOString(),
-    };
     await v2api.updateScorelist({
       ...sl,
-      payload_json: JSON.stringify(payload),
       certification_status: stage,
       certifications_json: JSON.stringify(certs),
       locked,

--- a/src/tournaments/RegistrationTournamentPage.tsx
+++ b/src/tournaments/RegistrationTournamentPage.tsx
@@ -21,8 +21,6 @@ const RegistrationTournamentPage = () => {
     Promise.all([tournamentService.syncFromBackend(), scheduleService.syncFromBackend()]).finally(() => setRefreshKey((value) => value + 1));
   }, []);
 
-  if (!user) return <Navigate to="/login" replace />;
-
   const tournamentId = normalizeId(id);
   const tournaments = useMemo(() => tournamentService.getTournaments(), [refreshKey]);
   const registrations = useMemo(() => tournamentService.getRegistrations(), [refreshKey]);
@@ -41,12 +39,15 @@ const RegistrationTournamentPage = () => {
   }
 
   const tournamentRegistrations = registrations.filter((item) => normalizeId(item.tournament_id) === tournamentId);
+  const playerRegistrations = user ? tournamentRegistrations.filter((item) => item.submitted_by === (user.player_id || user.username)) : [];
   const groupedBySeason = tournamentRegistrations.reduce<Record<string, RegistrationRecord[]>>((acc, item) => {
     const key = `${item.season_id || 'NA'}::${item.season_year || 'Open'}`;
     acc[key] = acc[key] || [];
     acc[key].push(item);
     return acc;
   }, {});
+
+  if (!user) return <Navigate to="/login" replace />;
 
   return (
     <div className="min-h-screen bg-background">
@@ -82,26 +83,31 @@ const RegistrationTournamentPage = () => {
         <ApprovedSchedulePanel tournamentId={tournament.tournament_id} />
 
         <Card>
-          <CardHeader><CardTitle>Registrations received</CardTitle></CardHeader>
+          <CardHeader><CardTitle>{user.type === 'player' ? 'My registration status' : 'Registrations received'}</CardTitle></CardHeader>
           <CardContent className="space-y-4">
-            {Object.entries(groupedBySeason).map(([key, items]) => (
-              <div key={key} className="rounded-lg border p-4 space-y-3">
-                <div className="flex items-center justify-between gap-2 flex-wrap">
-                  <p className="font-semibold">Season {items[0]?.season_year || 'Open'}{items[0]?.season_id ? ` • ${items[0].season_id}` : ''}</p>
-                  <Badge variant="outline">{items.length} registration(s)</Badge>
-                </div>
-                {items.map((registration) => (
-                  <div key={registration.registration_id} className="rounded-md border bg-muted/20 p-3 text-sm">
-                    <div className="flex items-center justify-between gap-2 flex-wrap">
-                      <span className="font-medium">{registration.team_name}</span>
-                      <Badge variant={registration.status === 'approved' ? 'default' : registration.status === 'rejected' ? 'destructive' : 'secondary'}>{registration.status}</Badge>
-                    </div>
-                    <p className="text-muted-foreground mt-1">Contact: {registration.contact_name} · {registration.contact_email}</p>
+            {(user.type === 'player' ? Object.entries(groupedBySeason).filter(([, items]) => items.some((item) => item.submitted_by === (user.player_id || user.username))) : Object.entries(groupedBySeason)).map(([key, items]) => {
+              const visibleItems = user.type === 'player' ? items.filter((item) => item.submitted_by === (user.player_id || user.username)) : items;
+              return (
+                <div key={key} className="rounded-lg border p-4 space-y-3">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <p className="font-semibold">Season {visibleItems[0]?.season_year || 'Open'}{visibleItems[0]?.season_id ? ` • ${visibleItems[0].season_id}` : ''}</p>
+                    <Badge variant="outline">{visibleItems.length} registration(s)</Badge>
                   </div>
-                ))}
-              </div>
-            ))}
-            {tournamentRegistrations.length === 0 && <p className="text-sm text-muted-foreground">No registrations submitted yet.</p>}
+                  {visibleItems.map((registration) => (
+                    <div key={registration.registration_id} className="rounded-md border bg-muted/20 p-3 text-sm">
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <span className="font-medium">{registration.team_name}</span>
+                        <Badge variant={registration.status === 'approved' ? 'default' : registration.status === 'rejected' ? 'destructive' : 'secondary'}>{registration.status}</Badge>
+                      </div>
+                      <p className="text-muted-foreground mt-1">Contact: {registration.contact_name} · {registration.contact_email}</p>
+                      {!!registration.review_notes && <p className="mt-2 text-muted-foreground"><strong>Admin note:</strong> {registration.review_notes}</p>}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+            {user.type === 'player' && playerRegistrations.length === 0 && <p className="text-sm text-muted-foreground">You have not submitted a registration for this tournament yet.</p>}
+            {user.type !== 'player' && tournamentRegistrations.length === 0 && <p className="text-sm text-muted-foreground">No registrations submitted yet.</p>}
           </CardContent>
         </Card>
       </div>

--- a/src/tournaments/TournamentsHubPage.tsx
+++ b/src/tournaments/TournamentsHubPage.tsx
@@ -61,8 +61,6 @@ const TournamentsHubPage = () => {
     Promise.all([tournamentService.syncFromBackend(), scheduleService.syncFromBackend()]).finally(() => setRefreshKey((value) => value + 1));
   }, []);
 
-  if (!user) return <Navigate to="/login" replace />;
-
   const registryTournaments = useMemo(() => tournamentService.getTournaments(), [refreshKey]);
   const registrations = useMemo(() => tournamentService.getRegistrations(), [refreshKey]);
 
@@ -108,12 +106,15 @@ const TournamentsHubPage = () => {
     if (activeTarget) setSelectedTargetKey(activeTarget.key);
   }, [activeTarget?.key]);
 
-  const activeRegistrations = registrations.filter((item) => normalizeId(item.tournament_id) === normalizeId(activeTarget?.tournament_id) && normalizeId(item.season_id) === normalizeId(activeTarget?.season_id));
-  const approvedSchedules = activeTarget ? scheduleService.getApprovedSchedulesForTournament(activeTarget.tournament_id) : [];
-  const linkedRecord = activeTarget?.registryRecord;
-
   const linkedSeasonCandidates = existingSeasonOptions.filter((item) => !item.registryRecord);
   const canCurrentUserApproveSchedules = canApproveSchedule(user);
+  const canCurrentUserApproveRegistrations = canApproveTournamentRegistration(user);
+  const isPlayerView = user?.type === 'player';
+  const currentActorId = getActorId(user);
+  const activeRegistrations = registrations.filter((item) => normalizeId(item.tournament_id) === normalizeId(activeTarget?.tournament_id) && normalizeId(item.season_id) === normalizeId(activeTarget?.season_id));
+  const visibleRegistrations = isPlayerView ? activeRegistrations.filter((item) => item.submitted_by === currentActorId) : activeRegistrations;
+  const approvedSchedules = activeTarget ? scheduleService.getApprovedSchedulesForTournament(activeTarget.tournament_id) : [];
+  const linkedRecord = activeTarget?.registryRecord;
 
   const createTournament = async () => {
     if (!user || !canManageTournament(user)) return;
@@ -310,6 +311,8 @@ const TournamentsHubPage = () => {
     toast({ title: `Registration ${status}`, description: 'The applicant can now see the updated status.' });
   };
 
+  if (!user) return <Navigate to="/login" replace />;
+
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
@@ -419,23 +422,31 @@ const TournamentsHubPage = () => {
                     </div>
                   )}
                 </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label>Team name</Label>
-                    <Input value={registrationForm.team_name} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, team_name: e.target.value }))} />
-                    <Label>Contact name</Label>
-                    <Input value={registrationForm.contact_name} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_name: e.target.value }))} />
-                    <Label>Contact email</Label>
-                    <Input value={registrationForm.contact_email} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_email: e.target.value }))} />
-                    <Label>Contact phone</Label>
-                    <Input value={registrationForm.contact_phone} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_phone: e.target.value }))} />
+                {isPlayerView ? (
+                  <>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label>Team name</Label>
+                        <Input value={registrationForm.team_name} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, team_name: e.target.value }))} />
+                        <Label>Contact name</Label>
+                        <Input value={registrationForm.contact_name} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_name: e.target.value }))} />
+                        <Label>Contact email</Label>
+                        <Input value={registrationForm.contact_email} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_email: e.target.value }))} />
+                        <Label>Contact phone</Label>
+                        <Input value={registrationForm.contact_phone} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, contact_phone: e.target.value }))} />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Players (one per line)</Label>
+                        <Textarea className="min-h-[220px]" value={registrationForm.players} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, players: e.target.value }))} />
+                      </div>
+                    </div>
+                    <Button onClick={submitRegistration} disabled={!registrationForm.team_name.trim()}><ShieldCheck className="h-4 w-4 mr-1" /> Submit Registration</Button>
+                  </>
+                ) : (
+                  <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                    Players can register their teams here and track only their own registration status. Admins and tournament directors can review submissions below.
                   </div>
-                  <div className="space-y-2">
-                    <Label>Players (one per line)</Label>
-                    <Textarea className="min-h-[220px]" value={registrationForm.players} onChange={(e) => setRegistrationForm((prev) => ({ ...prev, players: e.target.value }))} />
-                  </div>
-                </div>
-                <Button onClick={submitRegistration} disabled={!registrationForm.team_name.trim()}><ShieldCheck className="h-4 w-4 mr-1" /> Submit Registration</Button>
+                )}
               </CardContent>
             </Card>
           )}
@@ -443,9 +454,9 @@ const TournamentsHubPage = () => {
 
         {activeTarget && (
           <Card>
-            <CardHeader><CardTitle>Registrations</CardTitle></CardHeader>
+            <CardHeader><CardTitle>{isPlayerView ? 'My registrations' : 'Registrations'}</CardTitle></CardHeader>
             <CardContent className="space-y-4">
-              {activeRegistrations.map((registration) => {
+              {visibleRegistrations.map((registration) => {
                 const isEditing = editingRegistrationId === registration.registration_id;
                 return (
                   <div key={registration.registration_id} className="rounded-lg border p-4 space-y-3">
@@ -456,11 +467,11 @@ const TournamentsHubPage = () => {
                       </div>
                       <div className="flex gap-2 flex-wrap">
                         <Badge variant={registration.status === 'approved' ? 'default' : registration.status === 'rejected' ? 'destructive' : 'secondary'}>{registration.status}</Badge>
-                        <Button size="sm" variant="outline" onClick={() => isEditing ? setEditingRegistrationId(null) : startEditRegistration(registration)}>{isEditing ? 'Cancel' : 'Edit'}</Button>
-                        <Button size="sm" variant="destructive" onClick={() => removeRegistration(registration.registration_id)}>Delete</Button>
+                        {!isPlayerView && <Button size="sm" variant="outline" onClick={() => isEditing ? setEditingRegistrationId(null) : startEditRegistration(registration)}>{isEditing ? 'Cancel' : 'Edit'}</Button>}
+                        {!isPlayerView && <Button size="sm" variant="destructive" onClick={() => removeRegistration(registration.registration_id)}>Delete</Button>}
                       </div>
                     </div>
-                    {isEditing ? (
+                    {!isPlayerView && isEditing ? (
                       <div className="grid gap-3 md:grid-cols-2">
                         <div className="space-y-2">
                           <Label>Team name</Label>
@@ -492,7 +503,7 @@ const TournamentsHubPage = () => {
                         {!!registration.review_notes && <p className="text-sm text-muted-foreground"><strong>Review note:</strong> {registration.review_notes}</p>}
                       </>
                     )}
-                    {canApproveTournamentRegistration(user) && !isEditing && (
+                    {canCurrentUserApproveRegistrations && !isPlayerView && !isEditing && (
                       <div className="space-y-2">
                         <Textarea placeholder="Review note" value={reviewNotes[registration.registration_id] || ''} onChange={(e) => setReviewNotes((prev) => ({ ...prev, [registration.registration_id]: e.target.value }))} />
                         <div className="flex gap-2">
@@ -504,12 +515,12 @@ const TournamentsHubPage = () => {
                   </div>
                 );
               })}
-              {activeRegistrations.length === 0 && <p className="text-sm text-muted-foreground">No registrations submitted yet.</p>}
+              {visibleRegistrations.length === 0 && <p className="text-sm text-muted-foreground">{isPlayerView ? 'You have not submitted any registrations for this tournament yet.' : 'No registrations submitted yet.'}</p>}
             </CardContent>
           </Card>
         )}
 
-        {activeTarget && (
+        {activeTarget && !isPlayerView && (
           <Card>
             <CardHeader><CardTitle>Schedule Versions & Workflow</CardTitle></CardHeader>
             <CardContent className="space-y-4">
@@ -590,6 +601,24 @@ const TournamentsHubPage = () => {
                   </div>
                 );
               })}
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTarget && isPlayerView && approvedSchedules.length > 0 && (
+          <Card>
+            <CardHeader><CardTitle>Published schedule</CardTitle></CardHeader>
+            <CardContent className="space-y-3">
+              {approvedSchedules.map((schedule) => (
+                <div key={schedule.schedule_id} className="rounded-lg border p-4 space-y-2">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <p className="font-semibold">Version {schedule.version_number}</p>
+                    <Badge>{formatInIST(schedule.timestamp)}</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{schedule.change_log || 'Published tournament schedule.'}</p>
+                  <Button variant="outline" onClick={() => scheduleService.downloadPdf(schedule.schedule_id)}>Download published schedule</Button>
+                </div>
+              ))}
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
### Motivation
- Prevent digitally certified scorelists from being falsely marked as tampered after later management approvals. 
- Restore and simplify tournament registration pages so players can register and view only their own submissions while admins can review/approve. 
- Ensure management users cannot access player election flows and keep election participation limited to players. 
- Reduce clutter in the schedule approval roadmap by showing only the latest active schedule per tournament with an expand/collapse UI.

### Description
- Stop mutating the signed scorelist payload on certification by removing payload rewrites in `src/pages/AdminScorelistsPage.tsx` and only update certification metadata (`certification_status`, `certifications_json`, `locked`).
- Allow administrators to approve/reject tournament registrations by extending `canApproveTournamentRegistration` in `src/lib/accessControl.ts` to include `admin` accounts.
- Hide the Elections/Tournaments nav links for management users in `src/components/Navbar.tsx` and redirect management accounts away from the player-facing `src/elections/ElectionsPage.tsx` so only players/admins can access elections.
- Fix tournament registration and hub pages so they no longer show blank pages and so players see only their own registrations while admins/TDs retain editing, approve/reject, and schedule controls by updating `src/tournaments/RegistrationTournamentPage.tsx` and `src/tournaments/TournamentsHubPage.tsx` (visible registration filtering, role-gated UI, published schedule panel for players).
- Simplify the governance schedule roadmap to display only the latest schedule per tournament and add an expand/collapse control to inspect roadmap details and diffs in `src/components/admin/AdminGovernance.tsx`.

### Testing
- Ran TypeScript check with `tsc --noEmit`, which succeeded. 
- Ran `git diff --check`, which produced no issues. 
- Attempted ESLint on changed files with `eslint <files>`, which could not complete in this environment because project dev dependencies are not installed (ESLint failed due to missing packages). 
- Tried to run `npm ci` / `vite build` to run full build and lint in this environment but `npm ci` failed with a 403 from the package registry, so full runtime/build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be40cbf304832c8aa16dcdac47902d)