### PR TITLE
Fix timestamp sorting crashes and improve support UI clarity

### DIFF
--- a/src/components/admin/AdminSupport.tsx
+++ b/src/components/admin/AdminSupport.tsx
@@ -15,8 +15,9 @@ import { v2api, istNow, logAudit } from '@/lib/v2api';
 import { SupportTicket, SupportMessage, SupportCSAT, ManagementUser } from '@/lib/v2types';
 import { notifyTicketOwner, resolveSupportActor } from '@/lib/supportNotifications';
 import { generateId } from '@/lib/utils';
-import { Loader2, Search, MessageSquare, Clock, AlertTriangle, CheckCircle2, Send, StickyNote, UserRoundCheck, CalendarClock } from 'lucide-react';
+import { Loader2, Search, MessageSquare, Clock, AlertTriangle, Send, StickyNote, UserRoundCheck, CalendarClock } from 'lucide-react';
 import { getAdminNotificationRecipient, sendAdminCommunicationEmail } from '@/lib/mailer';
+import { compareTimestampsAsc, compareTimestampsDesc, formatInIST } from '@/lib/time';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'bg-primary/10 text-primary border-primary/30',
@@ -34,13 +35,6 @@ const PRIORITY_COLORS: Record<string, string> = {
 };
 
 const CATEGORIES = ['Account', 'Technical', 'Scorecard', 'Tournament', 'General', 'Bug Report'];
-
-const toIST = (value?: string) => {
-  if (!value) return '—';
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', dateStyle: 'medium', timeStyle: 'short' });
-};
 
 export function AdminSupportDashboard() {
   const { user } = useAuth();
@@ -101,14 +95,14 @@ export function AdminSupportDashboard() {
       const q = searchQuery.toLowerCase();
       result = result.filter((t) => t.subject.toLowerCase().includes(q) || t.ticket_id.toLowerCase().includes(q) || getPlayerName(t.created_by_user_id).toLowerCase().includes(q));
     }
-    return result.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    return result.sort((a, b) => compareTimestampsDesc(a.created_at, b.created_at));
   }, [tickets, filterStatus, filterCategory, filterPriority, searchQuery, players]);
 
   const ticketMessages = useMemo(() => selectedTicket
-    ? messages.filter((m) => m.ticket_id === selectedTicket.ticket_id).sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    ? messages.filter((m) => m.ticket_id === selectedTicket.ticket_id).sort((a, b) => compareTimestampsAsc(a.created_at, b.created_at))
     : [], [messages, selectedTicket]);
 
-  const latestCSAT = selectedTicket ? csatData.filter((c) => c.ticket_id === selectedTicket.ticket_id).sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime())[0] : null;
+  const latestCSAT = selectedTicket ? csatData.filter((c) => c.ticket_id === selectedTicket.ticket_id).sort((a, b) => compareTimestampsDesc(a.submitted_at, b.submitted_at))[0] : null;
 
   const handleReply = async () => {
     if (!replyText.trim() || !selectedTicket) return;
@@ -278,7 +272,7 @@ export function AdminSupportDashboard() {
               <div className="text-xs text-muted-foreground flex flex-wrap items-center gap-2">
                 <span>{getPlayerName(ticket.created_by_user_id)}</span>
                 <span>•</span>
-                <span>{toIST(ticket.created_at)} IST</span>
+                <span>{formatInIST(ticket.created_at)} IST</span>
                 {isSLABreached(ticket, 'resolution_due') ? <AlertTriangle className="h-4 w-4 text-destructive" /> : <Clock className="h-4 w-4" />}
               </div>
             </CardContent>
@@ -298,14 +292,14 @@ export function AdminSupportDashboard() {
                   <CardHeader className="pb-2"><CardTitle className="text-base">Conversation Timeline (IST)</CardTitle></CardHeader>
                   <CardContent className="space-y-3 max-h-[58vh] overflow-y-auto">
                     <div className="rounded-lg border p-3 bg-muted/30">
-                      <p className="text-xs text-muted-foreground">Ticket created • {toIST(selectedTicket.created_at)} IST</p>
+                      <p className="text-xs text-muted-foreground">Ticket created • {formatInIST(selectedTicket.created_at)} IST</p>
                       <p className="text-sm mt-1 whitespace-pre-wrap">{selectedTicket.description}</p>
                     </div>
                     {ticketMessages.map((msg) => (
                       <div key={msg.message_id} className={`rounded-lg border p-3 ${msg.is_internal_note ? 'bg-yellow-50 border-yellow-200' : msg.sender_role === 'admin' ? 'bg-primary/5 border-primary/20' : 'bg-background'}`}>
                         <div className="flex justify-between gap-2 text-xs mb-1">
                           <span className="font-semibold">{msg.sender_role === 'admin' ? getAssigneeName(msg.sender_id) : getPlayerName(msg.sender_id)}</span>
-                          <span className="text-muted-foreground">{toIST(msg.created_at)} IST</span>
+                          <span className="text-muted-foreground">{formatInIST(msg.created_at)} IST</span>
                         </div>
                         {msg.is_internal_note && <Badge variant="outline" className="mb-2">Internal Note</Badge>}
                         <p className="text-sm whitespace-pre-wrap">{msg.message_body}</p>
@@ -324,10 +318,10 @@ export function AdminSupportDashboard() {
                       </div>
                       <p><span className="text-muted-foreground">Raised by:</span> {getPlayerName(selectedTicket.created_by_user_id)}</p>
                       <p><span className="text-muted-foreground">Assigned:</span> {getAssigneeName(selectedTicket.assigned_admin_id)}</p>
-                      <p><span className="text-muted-foreground">First response due:</span> {toIST(selectedTicket.first_response_due)} IST</p>
-                      <p><span className="text-muted-foreground">Resolution due:</span> {toIST(selectedTicket.resolution_due)} IST</p>
-                      {selectedTicket.resolved_at && <p><span className="text-muted-foreground">Resolved:</span> {toIST(selectedTicket.resolved_at)} IST</p>}
-                      {selectedTicket.closed_at && <p><span className="text-muted-foreground">Closed:</span> {toIST(selectedTicket.closed_at)} IST</p>}
+                      <p><span className="text-muted-foreground">First response due:</span> {formatInIST(selectedTicket.first_response_due)} IST</p>
+                      <p><span className="text-muted-foreground">Resolution due:</span> {formatInIST(selectedTicket.resolution_due)} IST</p>
+                      {selectedTicket.resolved_at && <p><span className="text-muted-foreground">Resolved:</span> {formatInIST(selectedTicket.resolved_at)} IST</p>}
+                      {selectedTicket.closed_at && <p><span className="text-muted-foreground">Closed:</span> {formatInIST(selectedTicket.closed_at)} IST</p>}
                       <div className="pt-2 grid grid-cols-1 gap-2">
                         <Select value={selectedTicket.status} onValueChange={(v) => handleStatusChange(v as SupportTicket['status'])}>
                           <SelectTrigger><SelectValue /></SelectTrigger>

--- a/src/components/player/PlayerSupport.tsx
+++ b/src/components/player/PlayerSupport.tsx
@@ -11,9 +11,10 @@ import { useToast } from '@/hooks/use-toast';
 import { v2api, istNow, logAudit } from '@/lib/v2api';
 import { SupportTicket, SupportMessage, SupportCSAT, SLA_CONFIG, ManagementUser } from '@/lib/v2types';
 import { generateId } from '@/lib/utils';
-import { Loader2, Plus, Send, Star, CalendarClock } from 'lucide-react';
+import { Loader2, Plus, Send, Star, CalendarClock, AlertTriangle, BadgeCheck, Clock3, LifeBuoy } from 'lucide-react';
 import { resolveSupportActor } from '@/lib/supportNotifications';
 import { getAdminNotificationRecipient, sendAdminCommunicationEmail, sendSupportTicketCreatedEmail } from '@/lib/mailer';
+import { compareTimestampsAsc, compareTimestampsDesc, formatInIST } from '@/lib/time';
 
 const CATEGORIES = ['Account', 'Technical', 'Scorecard', 'Tournament', 'General', 'Bug Report'];
 
@@ -25,11 +26,11 @@ const STATUS_COLORS: Record<string, string> = {
   closed: 'bg-muted text-muted-foreground',
 };
 
-const toIST = (value?: string) => {
-  if (!value) return '—';
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', dateStyle: 'medium', timeStyle: 'short' });
+const PRIORITY_STYLES: Record<SupportTicket['priority'], string> = {
+  low: 'bg-muted text-muted-foreground border-border',
+  medium: 'bg-blue-100 text-blue-800 border-blue-200',
+  high: 'bg-orange-100 text-orange-800 border-orange-200',
+  critical: 'bg-destructive/10 text-destructive border-destructive/20',
 };
 
 interface PlayerSupportProps {
@@ -57,7 +58,7 @@ export function PlayerSupport({ playerId }: PlayerSupportProps) {
 
   const refresh = async (ticketToKeepOpen?: string) => {
     const [t, m, mgmt] = await Promise.all([v2api.getTickets(), v2api.getTicketMessages(), v2api.getManagementUsers()]);
-    const myTickets = t.filter((ticket) => ticket.created_by_user_id === playerId).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    const myTickets = t.filter((ticket) => ticket.created_by_user_id === playerId).sort((a, b) => compareTimestampsDesc(a.created_at, b.created_at));
     setTickets(myTickets);
     setMessages(m);
     setManagementUsers(mgmt);
@@ -164,8 +165,12 @@ export function PlayerSupport({ playerId }: PlayerSupportProps) {
   };
 
   const ticketMessages = useMemo(() => selectedTicket
-    ? messages.filter((m) => m.ticket_id === selectedTicket.ticket_id && !m.is_internal_note).sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    ? messages.filter((m) => m.ticket_id === selectedTicket.ticket_id && !m.is_internal_note).sort((a, b) => compareTimestampsAsc(a.created_at, b.created_at))
     : [], [messages, selectedTicket]);
+
+  const openCount = tickets.filter((ticket) => ['open', 'in_progress', 'waiting_for_user'].includes(ticket.status)).length;
+  const resolvedCount = tickets.filter((ticket) => ['resolved', 'closed'].includes(ticket.status)).length;
+  const criticalCount = tickets.filter((ticket) => ticket.priority === 'critical').length;
 
   const getAssigneeLabel = (id: string) => {
     if (!id) return 'Unassigned';
@@ -213,7 +218,15 @@ export function PlayerSupport({ playerId }: PlayerSupportProps) {
   return (
     <div className="space-y-4">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-        <h2 className="font-display text-xl font-bold">Support Center</h2>
+        <div className="space-y-1">
+          <h2 className="font-display text-xl font-bold">Support Center</h2>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="gap-1"><LifeBuoy className="h-3.5 w-3.5" />{tickets.length} total</Badge>
+            <Badge variant="outline" className="gap-1"><Clock3 className="h-3.5 w-3.5" />{openCount} active</Badge>
+            <Badge variant="outline" className="gap-1"><BadgeCheck className="h-3.5 w-3.5" />{resolvedCount} resolved</Badge>
+            <Badge variant="outline" className="gap-1"><AlertTriangle className="h-3.5 w-3.5" />{criticalCount} critical</Badge>
+          </div>
+        </div>
         <Dialog open={showCreate} onOpenChange={setShowCreate}>
           <DialogTrigger asChild>
             <Button size="sm"><Plus className="h-4 w-4 mr-1" /> Raise New Ticket</Button>
@@ -253,18 +266,21 @@ export function PlayerSupport({ playerId }: PlayerSupportProps) {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {tickets.map((ticket) => (
-          <Card key={ticket.ticket_id} className="cursor-pointer hover:border-primary/40" onClick={() => setSelectedTicket(ticket)}>
+          <Card key={ticket.ticket_id} className="cursor-pointer hover:border-primary/40 transition-all hover:shadow-sm" onClick={() => setSelectedTicket(ticket)}>
             <CardContent className="p-4 space-y-2">
               <div className="flex items-start justify-between gap-2">
-                <p className="font-semibold">{ticket.subject}</p>
+                <div>
+                  <p className="font-semibold">{ticket.subject}</p>
+                  <p className="text-xs text-muted-foreground font-mono">{ticket.ticket_id}</p>
+                </div>
                 <Badge className={STATUS_COLORS[ticket.status]}>{ticket.status.replace('_', ' ')}</Badge>
               </div>
               <div className="flex flex-wrap gap-2 text-xs">
                 <Badge variant="outline">{ticket.category}</Badge>
-                <Badge variant="outline">{ticket.priority}</Badge>
+                <Badge className={PRIORITY_STYLES[ticket.priority]}>{ticket.priority}</Badge>
                 <Badge variant="outline">Assigned: {getAssigneeLabel(ticket.assigned_admin_id)}</Badge>
               </div>
-              <p className="text-xs text-muted-foreground">Created: {toIST(ticket.created_at)} IST</p>
+              <p className="text-xs text-muted-foreground">Created: {formatInIST(ticket.created_at)} IST</p>
             </CardContent>
           </Card>
         ))}
@@ -286,16 +302,16 @@ export function PlayerSupport({ playerId }: PlayerSupportProps) {
                 <CardHeader className="pb-2"><CardTitle className="text-base">Detailed Timeline (IST)</CardTitle></CardHeader>
                 <CardContent className="space-y-3 max-h-[48vh] overflow-y-auto">
                   <div className="rounded-lg border p-3 bg-muted/30">
-                    <p className="text-xs text-muted-foreground">Ticket raised • {toIST(selectedTicket.created_at)} IST</p>
+                    <p className="text-xs text-muted-foreground">Ticket raised • {formatInIST(selectedTicket.created_at)} IST</p>
                     <p className="text-sm mt-1 whitespace-pre-wrap">{selectedTicket.description}</p>
                   </div>
                   <div className="rounded-lg border p-3">
-                    <p className="text-xs text-muted-foreground">First response due • {toIST(selectedTicket.first_response_due)} IST</p>
-                    <p className="text-xs text-muted-foreground">Resolution due • {toIST(selectedTicket.resolution_due)} IST</p>
+                    <p className="text-xs text-muted-foreground">First response due • {formatInIST(selectedTicket.first_response_due)} IST</p>
+                    <p className="text-xs text-muted-foreground">Resolution due • {formatInIST(selectedTicket.resolution_due)} IST</p>
                   </div>
                   {ticketMessages.map((msg) => (
                     <div key={msg.message_id} className={`rounded-lg border p-3 ${msg.sender_id === playerId ? 'bg-primary/5 border-primary/20' : ''}`}>
-                      <p className="text-xs text-muted-foreground">{msg.sender_id === playerId ? 'You' : getAssigneeLabel(msg.sender_id)} • {toIST(msg.created_at)} IST</p>
+                      <p className="text-xs text-muted-foreground">{msg.sender_id === playerId ? 'You' : getAssigneeLabel(msg.sender_id)} • {formatInIST(msg.created_at)} IST</p>
                       <p className="text-sm mt-1 whitespace-pre-wrap">{msg.message_body}</p>
                     </div>
                   ))}

--- a/src/elections/electionService.ts
+++ b/src/elections/electionService.ts
@@ -3,7 +3,7 @@ import { getActorId, getActorName } from '@/lib/accessControl';
 import { AuthUser } from '@/lib/types';
 import { logAudit, v2api } from '@/lib/v2api';
 import { ElectionAuditLog, ElectionRecord, ElectionResultSummary, ElectionTermRecord, NominationRecord, VoteRecord } from './types';
-import { nowIso } from '@/lib/time';
+import { compareTimestampsDesc, nowIso } from '@/lib/time';
 
 const STORAGE = {
   elections: 'club:elections',
@@ -90,19 +90,19 @@ export const electionService = {
   },
 
   getElections() {
-    return read<ElectionRecord>(STORAGE.elections).sort((a, b) => b.created_at.localeCompare(a.created_at));
+    return read<ElectionRecord>(STORAGE.elections).sort((a, b) => compareTimestampsDesc(a.created_at, b.created_at));
   },
 
   getNominations() {
-    return read<NominationRecord>(STORAGE.nominations).sort((a, b) => b.created_at.localeCompare(a.created_at));
+    return read<NominationRecord>(STORAGE.nominations).sort((a, b) => compareTimestampsDesc(a.created_at, b.created_at));
   },
 
   getVotes() {
-    return read<VoteRecord>(STORAGE.votes).sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
+    return read<VoteRecord>(STORAGE.votes).sort((a, b) => compareTimestampsDesc(a.submitted_at, b.submitted_at));
   },
 
   getTerms() {
-    return read<ElectionTermRecord>(STORAGE.terms).sort((a, b) => b.assigned_at.localeCompare(a.assigned_at));
+    return read<ElectionTermRecord>(STORAGE.terms).sort((a, b) => compareTimestampsDesc(a.assigned_at, b.assigned_at));
   },
 
   getAuditLogs() {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -29,6 +29,16 @@ export function nowIso() {
   return new Date().toISOString();
 }
 
+export function compareTimestampsDesc(left: unknown, right: unknown) {
+  const leftTime = parseTimestamp(String(left ?? ''))?.getTime() ?? Number.NEGATIVE_INFINITY;
+  const rightTime = parseTimestamp(String(right ?? ''))?.getTime() ?? Number.NEGATIVE_INFINITY;
+  return rightTime - leftTime;
+}
+
+export function compareTimestampsAsc(left: unknown, right: unknown) {
+  return compareTimestampsDesc(right, left);
+}
+
 export function formatInIST(value?: string | Date | null, options?: Intl.DateTimeFormatOptions) {
   const parsed = value instanceof Date ? value : parseTimestamp(value ?? '');
   if (!parsed) return '—';

--- a/src/schedules/scheduleService.ts
+++ b/src/schedules/scheduleService.ts
@@ -4,7 +4,7 @@ import { generateId } from '@/lib/utils';
 import { logAudit, v2api } from '@/lib/v2api';
 import { ScheduleApprovalRecord, ScheduleAuditLog, ScheduleDiffEntry, ScheduleMatch, ScheduleRecord } from './types';
 import { getScheduleDetailedStatus } from '@/lib/workflowStatus';
-import { formatInIST, formatScheduleSlotInIST, nowIso } from '@/lib/time';
+import { compareTimestampsDesc, formatInIST, formatScheduleSlotInIST, nowIso } from '@/lib/time';
 
 const STORAGE = {
   schedules: 'club:schedules',
@@ -113,10 +113,10 @@ export const scheduleService = {
     }
   },
   getSchedules() {
-    return read<ScheduleRecord>(STORAGE.schedules).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return read<ScheduleRecord>(STORAGE.schedules).sort((a, b) => compareTimestampsDesc(a.timestamp, b.timestamp));
   },
   getApprovals() {
-    return read<ScheduleApprovalRecord>(STORAGE.approvals).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return read<ScheduleApprovalRecord>(STORAGE.approvals).sort((a, b) => compareTimestampsDesc(a.timestamp, b.timestamp));
   },
   getAuditLogs() {
     return read<ScheduleAuditLog>(STORAGE.audit);

--- a/src/tournaments/TournamentsHubPage.tsx
+++ b/src/tournaments/TournamentsHubPage.tsx
@@ -38,6 +38,14 @@ type RegistrationTarget = {
 };
 
 const parsePlayers = (value: string) => value.split('\n').map((item) => item.trim()).filter(Boolean);
+const readPlayers = (value: string) => {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map((item) => String(item).trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+};
 
 const TournamentsHubPage = () => {
   const { user } = useAuth();
@@ -232,7 +240,7 @@ const TournamentsHubPage = () => {
       contact_name: registration.contact_name,
       contact_email: registration.contact_email,
       contact_phone: registration.contact_phone,
-      players: (JSON.parse(registration.players_json) as string[]).join('\n'),
+      players: readPlayers(registration.players_json).join('\n'),
       status: registration.status,
       review_notes: registration.review_notes,
     });
@@ -499,7 +507,7 @@ const TournamentsHubPage = () => {
                       </div>
                     ) : (
                       <>
-                        <p className="text-sm">Players: {(JSON.parse(registration.players_json) as string[]).join(', ') || '—'}</p>
+                        <p className="text-sm">Players: {readPlayers(registration.players_json).join(', ') || '—'}</p>
                         {!!registration.review_notes && <p className="text-sm text-muted-foreground"><strong>Review note:</strong> {registration.review_notes}</p>}
                       </>
                     )}

--- a/src/tournaments/tournamentService.ts
+++ b/src/tournaments/tournamentService.ts
@@ -1,4 +1,5 @@
 import { getActorId, getActorName } from '@/lib/accessControl';
+import { compareTimestampsDesc } from '@/lib/time';
 import { AuthUser } from '@/lib/types';
 import { generateId } from '@/lib/utils';
 import { logAudit, v2api } from '@/lib/v2api';
@@ -70,12 +71,12 @@ export const tournamentService = {
     }
   },
   getTournaments() {
-    return read<TournamentRegistryRecord>(STORAGE.tournaments).sort((a, b) => b.created_at.localeCompare(a.created_at));
+    return read<TournamentRegistryRecord>(STORAGE.tournaments).sort((a, b) => compareTimestampsDesc(a.created_at, b.created_at));
   },
   getRegistrations() {
     return read<RegistrationRecord>(STORAGE.registrations)
       .map((item) => ({ ...item, registration_key: item.registration_key || buildRegistrationKey(item) }))
-      .sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
+      .sort((a, b) => compareTimestampsDesc(a.submitted_at, b.submitted_at));
   },
   getAuditLogs() {
     return read<TournamentAuditLog>(STORAGE.audit);


### PR DESCRIPTION
### Motivation

- The app crashed when sorting registrations because stored timestamp values were not always strings and `localeCompare` failed, so sorting must use robust parsed timestamp comparisons. 
- The player-list parsing for tournament registrations could throw on malformed `players_json` and needed to be defensive.  
- Support UI needed clearer status/priority affordances and consistent IST timestamp rendering for better support workflows.

### Description

- Added robust timestamp comparators `compareTimestampsDesc` and `compareTimestampsAsc` in `src/lib/time.ts` and replaced fragile `localeCompare`/string-date sorts across services (`tournamentService`, `scheduleService`, `electionService`) and support views so ordering tolerates non-string timestamps.  
- Guarded player list handling by adding `readPlayers` and using it when reading `players_json` in `src/tournaments/TournamentsHubPage.tsx` to avoid crashes from malformed stored JSON.  
- Polished the support UI in `src/components/player/PlayerSupport.tsx` and `src/components/admin/AdminSupport.tsx` by adding summary chips/badges, styled priority chips, consistent IST formatting via `formatInIST`, improved ticket card layout, and safer message/ticket ordering using the new comparators.  
- Minor related changes: updated schedule listing to use the new comparators and removed a now-unused import; committed all updates.

### Testing

- Attempted `npm install` but it failed due to registry access policy (`403 Forbidden`) in this environment, so dependencies could not be installed and full build/test could not be executed.  
- Attempted `npm run build` and `npm test -- --runInBand` but both were blocked because `npm install` could not complete, so build/test did not run.  
- Invoked TypeScript check `tsc --noEmit -p tsconfig.app.json`, which could not finish in this environment because `vitest/globals` types are referenced but not available without installing dev dependencies.  
- Performed code inspection and local static edits, and committed the changes as commit `3b213a0` (`Fix timestamp sorting and polish support UI`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be45627ef8832ca863f230e00af61d)