### PR TITLE
Fix mobile certificate preview scaling across dashboard views

### DIFF
--- a/src/components/certificates/CertificatePreview.tsx
+++ b/src/components/certificates/CertificatePreview.tsx
@@ -283,7 +283,7 @@ export const CertificatePreview = memo(function CertificatePreview({
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScale, setAutoScale] = useState(1);
   const isMobile = useIsMobile();
-  const PREVIEW_BASE_WIDTH = 1120;
+  const PREVIEW_BASE_WIDTH = isMobile ? 760 : 1120;
   const PREVIEW_BASE_HEIGHT = Math.round(PREVIEW_BASE_WIDTH * 210 / 297);
   const templateConfig = useMemo(() => {
     const raw = String(template?.design_config || '').trim();


### PR DESCRIPTION
### Motivation
- Certificate previews rendered too small and were hard to read on narrow/mobile screens in the admin, player, and team dashboards, so the base render width needs to be reduced for mobile to improve readability.

### Description
- Changed `PREVIEW_BASE_WIDTH` in `src/components/certificates/CertificatePreview.tsx` from `1120` to `isMobile ? 760 : 1120` so the preview auto-scaling produces a larger, more readable certificate on mobile devices.

### Testing
- Attempted `npm run build` but the build could not be validated in this environment because `vite` is not installed (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d685a2f0188322be7014d5e38d2593)