### PR TITLE
Enhance verification UI: file upload, persistent draft, result tones, and guidance panel

### DIFF
--- a/src/pages/VerificationPage.tsx
+++ b/src/pages/VerificationPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { Navbar } from '@/components/Navbar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -7,13 +7,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { v2api } from '@/lib/v2api';
 import { CertificateRecord, isCertificateAuthentic, normalizeCertificateId } from '@/lib/certificates';
 import { DigitalScorelist } from '@/lib/v2types';
 import { verifyScorelist } from '@/lib/scorelist';
-import { Camera, Loader2, Search, ShieldCheck, ShieldX } from 'lucide-react';
+import { AlertTriangle, Camera, CheckCircle2, FileUp, Loader2, Search, ShieldCheck, ShieldX, Upload, XCircle } from 'lucide-react';
 
 type VerifyMode = 'certificate' | 'scorelist';
+
+const DRAFT_KEY = 'verification-portal-draft-v1';
+const MAX_UPLOAD_SIZE_BYTES = 1024 * 1024;
 
 type VerificationState =
   | { kind: 'idle' }
@@ -47,6 +52,46 @@ const parseVerificationInput = (value: string, fallbackMode: VerifyMode): { mode
   return { mode: 'scorelist', id: raw };
 };
 
+const getVerificationTone = (state: VerificationState): { icon: typeof AlertTriangle; badge: string; classes: string; progress: number; detail: string } => {
+  if (state.kind === 'idle') {
+    return {
+      icon: AlertTriangle,
+      badge: 'Awaiting Input',
+      classes: 'border-border bg-card',
+      progress: 15,
+      detail: 'Paste a verification URL/ID, scan a QR, or upload a file containing the identifier.',
+    };
+  }
+
+  if (state.kind === 'not_found') {
+    return {
+      icon: XCircle,
+      badge: 'Needs Action',
+      classes: 'border-destructive/40 bg-destructive/5',
+      progress: 100,
+      detail: `No ${state.mode} was found for the submitted identifier. Check for typos and retry.`,
+    };
+  }
+
+  if (state.kind === 'certificate') {
+    return {
+      icon: state.valid ? CheckCircle2 : XCircle,
+      badge: state.valid ? 'Approved' : 'Rejected',
+      classes: state.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5',
+      progress: 100,
+      detail: state.valid ? 'Certificate metadata and authenticity checks completed successfully.' : 'Certificate record exists but authenticity validation failed.',
+    };
+  }
+
+  return {
+    icon: state.valid ? CheckCircle2 : XCircle,
+    badge: state.valid ? 'Approved' : 'Rejected',
+    classes: state.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5',
+    progress: 100,
+    detail: state.valid ? 'Scorelist hash and integrity checks passed.' : state.reason || 'Scorelist integrity validation failed.',
+  };
+};
+
 export default function VerificationPage() {
   const [params] = useSearchParams();
   const routeParams = useParams<{ type?: string; id?: string }>();
@@ -60,6 +105,8 @@ export default function VerificationPage() {
   const [scannerMessage, setScannerMessage] = useState('');
   const [scannerOpen, setScannerOpen] = useState(false);
   const [scannerBusy, setScannerBusy] = useState(false);
+  const [uploadName, setUploadName] = useState('');
+  const [uploadError, setUploadError] = useState('');
   const videoRef = useRef<HTMLVideoElement>(null);
   const scannerIntervalRef = useRef<number | null>(null);
   const scannerStreamRef = useRef<MediaStream | null>(null);
@@ -77,6 +124,26 @@ export default function VerificationPage() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    const draftRaw = window.localStorage.getItem(DRAFT_KEY);
+    if (!draftRaw) return;
+    try {
+      const parsed = JSON.parse(draftRaw) as { mode: VerifyMode; inputValue: string };
+      if (parsed.mode === 'certificate' || parsed.mode === 'scorelist') {
+        setMode(parsed.mode);
+      }
+      if (typeof parsed.inputValue === 'string') {
+        setInputValue(parsed.inputValue);
+      }
+    } catch {
+      window.localStorage.removeItem(DRAFT_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(DRAFT_KEY, JSON.stringify({ mode, inputValue }));
+  }, [inputValue, mode]);
 
   useEffect(() => {
     const explicitType = routeParams.type === 'scorelist' ? 'scorelist' : routeParams.type === 'certificate' ? 'certificate' : null;
@@ -111,6 +178,8 @@ export default function VerificationPage() {
     if (result.kind !== 'certificate') return null;
     return result.item;
   }, [result]);
+
+  const verificationTone = useMemo(() => getVerificationTone(result), [result]);
 
   const runVerification = async (value: string, selectedMode: VerifyMode): Promise<boolean> => {
     const parsed = parseVerificationInput(value, selectedMode);
@@ -152,6 +221,46 @@ export default function VerificationPage() {
     if (isSuccess) {
       setInputValue('');
     }
+  };
+
+  const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    setUploadError('');
+    if (!file) return;
+
+    setUploadName(file.name);
+    if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+      setUploadError('File is too large. Upload a file under 1 MB.');
+      return;
+    }
+
+    const typeLooksValid = ['text/plain', 'application/json', 'text/csv'].includes(file.type) || /\.(txt|json|csv)$/i.test(file.name);
+    if (!typeLooksValid) {
+      setUploadError('Unsupported file type. Use TXT, CSV, or JSON.');
+      return;
+    }
+
+    const text = await file.text();
+    let extracted = text.trim();
+
+    if (file.type === 'application/json' || file.name.toLowerCase().endsWith('.json')) {
+      try {
+        const parsed = JSON.parse(text) as { verificationId?: string; url?: string; id?: string };
+        extracted = String(parsed.verificationId || parsed.url || parsed.id || '').trim();
+      } catch {
+        setUploadError('JSON file could not be parsed.');
+        return;
+      }
+    } else {
+      extracted = text.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || '';
+    }
+
+    if (!extracted) {
+      setUploadError('No verification ID or URL was found in the uploaded file.');
+      return;
+    }
+
+    setInputValue(extracted);
   };
 
   const startScanner = async () => {
@@ -217,125 +326,193 @@ export default function VerificationPage() {
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
-      <div className="container mx-auto max-w-4xl px-4 py-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>Public Verification Portal</CardTitle>
-            <CardDescription>
-              No login required. Verify both digital scorelists and certificates using scanner, URL, or direct ID.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <Tabs value={mode} onValueChange={(value) => setMode(value as VerifyMode)}>
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="certificate">Certificate</TabsTrigger>
-                <TabsTrigger value="scorelist">Digital Scorelist</TabsTrigger>
-              </TabsList>
-              <TabsContent value="certificate" />
-              <TabsContent value="scorelist" />
-            </Tabs>
+      <div className="container mx-auto max-w-6xl px-4 py-8">
+        <div className="grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
+          <Card className="transition-shadow duration-300 motion-reduce:transition-none hover:shadow-lg">
+            <CardHeader>
+              <CardTitle>Public Verification Portal</CardTitle>
+              <CardDescription>
+                Verify digital scorelists and certificates instantly with URL/ID search, QR scan, or file upload.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <Tabs value={mode} onValueChange={(value) => setMode(value as VerifyMode)}>
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="certificate">Certificate</TabsTrigger>
+                  <TabsTrigger value="scorelist">Digital Scorelist</TabsTrigger>
+                </TabsList>
+                <TabsContent value="certificate" />
+                <TabsContent value="scorelist" />
+              </Tabs>
 
-            <form onSubmit={onSubmit} className="space-y-3">
-              <div className="grid gap-2">
-                <Label htmlFor="verify-input">
-                  {mode === 'certificate' ? 'Certificate URL / Certificate ID' : 'Scorelist URL / Scorelist ID'}
-                </Label>
-                <Input
-                  id="verify-input"
-                  placeholder={mode === 'certificate' ? 'Example: /verify?certificate_id=CERT-1001' : 'Example: /verify-scorelist/DS-1001'}
-                  value={inputValue}
-                  onChange={(event) => setInputValue(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button type="submit" disabled={loadingData || verifying}>
-                  {verifying ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Search className="mr-2 h-4 w-4" />}
-                  Verify
-                </Button>
-                <Button type="button" variant="outline" onClick={startScanner}>
-                  <Camera className="mr-2 h-4 w-4" /> Scan QR
-                </Button>
-              </div>
-            </form>
+              <form onSubmit={onSubmit} className="space-y-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="verify-input">
+                    {mode === 'certificate' ? 'Certificate URL / Certificate ID' : 'Scorelist URL / Scorelist ID'}
+                  </Label>
+                  <Input
+                    id="verify-input"
+                    placeholder={mode === 'certificate' ? 'Example: /verify?certificate_id=CERT-1001' : 'Example: /verify-scorelist/DS-1001'}
+                    value={inputValue}
+                    onChange={(event) => setInputValue(event.target.value)}
+                    className="transition-all duration-200 motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-primary"
+                  />
+                  <p className="text-xs text-muted-foreground">Accepted formats: full verification URL, raw certificate ID, or scorelist ID.</p>
+                </div>
 
-            {scannerOpen && (
-              <Card className="border-dashed">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-base">QR Scanner</CardTitle>
-                  <CardDescription>Point your camera at a verification QR code.</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <video ref={videoRef} className="w-full rounded-md border bg-black/90" muted playsInline />
-                  {scannerMessage && <p className="text-sm text-muted-foreground">{scannerMessage}</p>}
-                  <Button type="button" variant="secondary" onClick={stopScanner} disabled={!scannerBusy && !scannerMessage}>
-                    Close scanner
+                <div className="rounded-lg border border-dashed p-3">
+                  <Label htmlFor="verify-upload" className="mb-2 flex items-center gap-2 text-sm">
+                    <Upload className="h-4 w-4" /> Upload ID/URL file (TXT, CSV, JSON under 1 MB)
+                  </Label>
+                  <Input id="verify-upload" type="file" accept=".txt,.csv,.json" onChange={handleUpload} className="cursor-pointer" />
+                  {(uploadName || uploadError) && (
+                    <div className="mt-2 text-xs">
+                      {uploadName && <p className="text-muted-foreground">Selected file: {uploadName}</p>}
+                      {uploadError && <p className="text-destructive">{uploadError}</p>}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Button type="submit" disabled={loadingData || verifying} className="transition-transform duration-200 motion-reduce:transition-none hover:scale-[1.02]">
+                    {verifying ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Search className="mr-2 h-4 w-4" />}
+                    Verify now
                   </Button>
-                </CardContent>
-              </Card>
-            )}
-
-            {loadingData && (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" /> Loading verification records...
-              </div>
-            )}
-
-            {result.kind === 'not_found' && (
-              <Card className="border-destructive/40 bg-destructive/5">
-                <CardContent className="pt-6">
-                  <Badge variant="destructive">Not Found</Badge>
-                  <p className="mt-2 text-sm">
-                    No {result.mode} found for <span className="font-mono">{result.value}</span>.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
-
-            {certificate && result.kind === 'certificate' && (
-              <Card className={result.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5'}>
-                <CardContent className="space-y-3 pt-6">
-                  <Badge variant={result.valid ? 'default' : 'destructive'} className="inline-flex items-center gap-1">
-                    {result.valid ? <ShieldCheck className="h-3 w-3" /> : <ShieldX className="h-3 w-3" />}
-                    {result.valid ? 'Valid Certificate' : 'Invalid Certificate'}
-                  </Badge>
-                  <div className="grid gap-2 text-sm md:grid-cols-2">
-                    <p><span className="font-medium">Certificate ID:</span> <span className="font-mono">{certificate.id}</span></p>
-                    <p><span className="font-medium">Recipient:</span> {certificate.recipient_name}</p>
-                    <p><span className="font-medium">Type:</span> {certificate.type}</p>
-                    <p><span className="font-medium">Tournament:</span> {certificate.tournament}</p>
-                    <p><span className="font-medium">Season:</span> {certificate.season}</p>
-                    <p><span className="font-medium">Status:</span> {certificate.status}</p>
-                    <p><span className="font-medium">Certified At:</span> {certificate.certified_at || 'Not certified'}</p>
-                    <p><span className="font-medium">Certified By:</span> {certificate.certified_by || 'Unknown'}</p>
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-
-            {result.kind === 'scorelist' && (
-              <Card className={result.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5'}>
-                <CardContent className="space-y-3 pt-6">
-                  <Badge variant={result.valid ? 'default' : 'destructive'} className="inline-flex items-center gap-1">
-                    {result.valid ? <ShieldCheck className="h-3 w-3" /> : <ShieldX className="h-3 w-3" />}
-                    {result.valid ? 'Authentic Scorelist' : 'Tampered / Invalid Scorelist'}
-                  </Badge>
-                  {result.reason && <p className="text-sm text-destructive">{result.reason}</p>}
-                  <div className="grid gap-2 text-sm md:grid-cols-2">
-                    <p><span className="font-medium">Scorelist ID:</span> <span className="font-mono">{result.item.scorelist_id}</span></p>
-                    <p><span className="font-medium">Scope:</span> {result.item.scope_type}</p>
-                    <p><span className="font-medium">Generated By:</span> {result.item.generated_by}</p>
-                    <p><span className="font-medium">Generated At:</span> {result.item.generated_at}</p>
-                  </div>
-                  <Button asChild variant="outline" size="sm">
-                    <Link to={`/verify-scorelist/${encodeURIComponent(result.item.scorelist_id)}`}>
-                      Open full scorelist verification page
-                    </Link>
+                  <Button type="button" variant="outline" onClick={startScanner} className="transition-colors duration-200 motion-reduce:transition-none">
+                    <Camera className="mr-2 h-4 w-4" /> Scan QR
                   </Button>
+                </div>
+              </form>
+
+              {scannerOpen && (
+                <Card className="border-dashed">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">QR Scanner</CardTitle>
+                    <CardDescription>Point your camera at a verification QR code.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <video ref={videoRef} className="w-full rounded-md border bg-black/90" muted playsInline />
+                    {scannerMessage && <p className="text-sm text-muted-foreground">{scannerMessage}</p>}
+                    <Button type="button" variant="secondary" onClick={stopScanner} disabled={!scannerBusy && !scannerMessage}>
+                      Close scanner
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+
+              {loadingData && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading verification records...
+                </div>
+              )}
+
+              <Card className={verificationTone.classes}>
+                <CardContent className="space-y-3 pt-6">
+                  <div className="flex items-center justify-between gap-2">
+                    <Badge variant={result.kind === 'not_found' || (result.kind !== 'idle' && 'valid' in result && !result.valid) ? 'destructive' : 'default'}>
+                      {verificationTone.badge}
+                    </Badge>
+                    <verificationTone.icon className="h-4 w-4" />
+                  </div>
+                  <p className="text-sm">{verificationTone.detail}</p>
+                  <Progress value={verifying ? 70 : verificationTone.progress} className="h-2" aria-label="Verification status progress" />
                 </CardContent>
               </Card>
-            )}
-          </CardContent>
-        </Card>
+
+              {certificate && result.kind === 'certificate' && (
+                <Card className={result.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5'}>
+                  <CardContent className="space-y-3 pt-6">
+                    <Badge variant={result.valid ? 'default' : 'destructive'} className="inline-flex items-center gap-1">
+                      {result.valid ? <ShieldCheck className="h-3 w-3" /> : <ShieldX className="h-3 w-3" />}
+                      {result.valid ? 'Valid Certificate' : 'Invalid Certificate'}
+                    </Badge>
+                    <div className="grid gap-2 text-sm md:grid-cols-2">
+                      <p><span className="font-medium">Certificate ID:</span> <span className="font-mono">{certificate.id}</span></p>
+                      <p><span className="font-medium">Recipient:</span> {certificate.recipient_name}</p>
+                      <p><span className="font-medium">Type:</span> {certificate.type}</p>
+                      <p><span className="font-medium">Tournament:</span> {certificate.tournament}</p>
+                      <p><span className="font-medium">Season:</span> {certificate.season}</p>
+                      <p><span className="font-medium">Status:</span> {certificate.status}</p>
+                      <p><span className="font-medium">Certified At:</span> {certificate.certified_at || 'Not certified'}</p>
+                      <p><span className="font-medium">Certified By:</span> {certificate.certified_by || 'Unknown'}</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {result.kind === 'scorelist' && (
+                <Card className={result.valid ? 'border-primary/40 bg-primary/5' : 'border-destructive/40 bg-destructive/5'}>
+                  <CardContent className="space-y-3 pt-6">
+                    <Badge variant={result.valid ? 'default' : 'destructive'} className="inline-flex items-center gap-1">
+                      {result.valid ? <ShieldCheck className="h-3 w-3" /> : <ShieldX className="h-3 w-3" />}
+                      {result.valid ? 'Authentic Scorelist' : 'Tampered / Invalid Scorelist'}
+                    </Badge>
+                    {result.reason && <p className="text-sm text-destructive">{result.reason}</p>}
+                    <div className="grid gap-2 text-sm md:grid-cols-2">
+                      <p><span className="font-medium">Scorelist ID:</span> <span className="font-mono">{result.item.scorelist_id}</span></p>
+                      <p><span className="font-medium">Scope:</span> {result.item.scope_type}</p>
+                      <p><span className="font-medium">Generated By:</span> {result.item.generated_by}</p>
+                      <p><span className="font-medium">Generated At:</span> {result.item.generated_at}</p>
+                    </div>
+                    <Button asChild variant="outline" size="sm">
+                      <Link to={`/verify-scorelist/${encodeURIComponent(result.item.scorelist_id)}`}>
+                        Open full scorelist verification page
+                      </Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="h-fit">
+            <CardHeader>
+              <CardTitle className="text-lg">Guidance & Trust Center</CardTitle>
+              <CardDescription>Why we verify, what to upload, and what happens next.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-md border bg-muted/20 p-3 text-sm">
+                <p className="font-medium">Expected review and verification timeline</p>
+                <p className="mt-1 text-muted-foreground">Automated checks return instantly. Manual escalation (if needed) is typically reviewed within 24 hours.</p>
+              </div>
+
+              <div className="rounded-md border bg-muted/20 p-3 text-sm">
+                <p className="font-medium">Privacy first</p>
+                <p className="mt-1 text-muted-foreground">Submitted identifiers are used only to validate official records and are not shared externally.</p>
+              </div>
+
+              <Accordion type="single" collapsible className="w-full">
+                <AccordionItem value="accepted-docs">
+                  <AccordionTrigger>Accepted file inputs</AccordionTrigger>
+                  <AccordionContent>
+                    Upload TXT, CSV, or JSON files. JSON keys supported: <span className="font-mono">verificationId</span>, <span className="font-mono">url</span>, or <span className="font-mono">id</span>.
+                  </AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="verification-fails">
+                  <AccordionTrigger>What if verification fails?</AccordionTrigger>
+                  <AccordionContent>
+                    Re-check ID formatting, confirm source authenticity, then retry. If the issue persists, contact support with the original source document.
+                  </AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="support">
+                  <AccordionTrigger>Need support?</AccordionTrigger>
+                  <AccordionContent>
+                    Share the identifier and issue details with the operations desk. The support team can assist with resubmission and manual checks.
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+
+              <Button variant="secondary" className="w-full" asChild>
+                <Link to="/documents">Open documents portal</Link>
+              </Button>
+
+              <div className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+                <p className="flex items-center gap-2 font-medium text-foreground"><FileUp className="h-4 w-4" /> Pro tip</p>
+                <p className="mt-1">Keep a plain-text copy of each issued ID to speed up bulk checks and reduce formatting errors.</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Improve the public verification experience by supporting file uploads and QR scanning, providing clearer success/failure feedback, and surfacing guidance for users.
- Persist the current verification draft so users don't lose typed input when navigating away or reloading.
- Make the verification results more informative and accessible with progress indicators, icons, and a dedicated trust/guidance side panel.

### Description
- Added file upload support via `handleUpload` with size/type checks (TXT/CSV/JSON), JSON key extraction, and error messages, and wired it to set `inputValue` for verification; defined `MAX_UPLOAD_SIZE_BYTES` and `DRAFT_KEY` constants. 
- Persisted verification draft to `localStorage` with two `useEffect` hooks to load and save `{ mode, inputValue }` under `DRAFT_KEY`.
- Introduced `getVerificationTone` and `verificationTone` (memoized) to centralize result badge, icon, classes, progress value, and detail text, and replaced parts of the result UI to use this tone and a `Progress` bar.
- Reworked the page layout to a two-column responsive grid, added upload control, improved input styles, polished QR scanner card placement, and added a new right-hand "Guidance & Trust Center" card with `Accordion` content and helpful copy.
- Minor imports and icon additions (`Upload`, `XCircle`, `CheckCircle2`, `FileUp`, `AlertTriangle`) and small UX tweaks (placeholders, helper text, button styling), while preserving core verification logic in `runVerification`, scanner start/stop, and certificate/scorelist result rendering.

### Testing
- Ran TypeScript type-check and a development build (`npm run build` / `tsc`) to ensure no type errors and UI compiles successfully, and the build completed without errors. 
- Executed the project's test suite (`npm test`) and verified all automated tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cd396d00832295cc5e37f08d8981)