### PR TITLE
Fix mobile certificate preview scaling across dashboards

### DIFF
--- a/src/components/certificates/CertificatePreview.tsx
+++ b/src/components/certificates/CertificatePreview.tsx
@@ -339,7 +339,8 @@ export const CertificatePreview = memo(function CertificatePreview({
     const measure = () => {
       const containerWidth = el.clientWidth;
       const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : containerWidth;
-      const safeViewportWidth = Math.max(280, viewportWidth - (isMobile ? 4 : 24));
+      const horizontalPadding = isMobile ? 12 : 24;
+      const safeViewportWidth = Math.max(260, viewportWidth - horizontalPadding);
       const availableWidth = Math.min(containerWidth, safeViewportWidth);
       const scale = Math.min(1, availableWidth / PREVIEW_BASE_WIDTH);
       setAutoScale(scale);
@@ -412,23 +413,23 @@ export const CertificatePreview = memo(function CertificatePreview({
         {expanded && (
           <>
             {/* Certificate body — exported to PDF */}
-            <div className="p-1 sm:p-4" ref={containerRef}>
+            <div className="overflow-x-hidden p-1 sm:p-4" ref={containerRef}>
               <div
                 className="mx-auto flex w-full justify-center overflow-hidden"
                 style={{
-                  height: isMobile ? 'auto' : `${Math.round(PREVIEW_BASE_HEIGHT * autoScale)}px`,
+                  height: `${Math.round(PREVIEW_BASE_HEIGHT * autoScale)}px`,
                 }}
               >
               <div
                 ref={ref}
                 className="certificate-pdf-root mx-auto overflow-hidden"
                 style={{
-                  width: isMobile ? '100%' : `${PREVIEW_BASE_WIDTH}px`,
+                  width: `${PREVIEW_BASE_WIDTH}px`,
                   maxWidth: `${PREVIEW_BASE_WIDTH}px`,
                   aspectRatio: '297 / 210',
-                  transform: isMobile ? undefined : `scale(${autoScale})`,
-                  transformOrigin: isMobile ? undefined : 'top center',
-                  transition: isMobile ? undefined : 'transform 180ms ease',
+                  transform: `scale(${autoScale})`,
+                  transformOrigin: 'top center',
+                  transition: 'transform 180ms ease',
                   background: theme.outerBg,
                   backgroundImage: templateBackgroundUrl ? `url(${templateBackgroundUrl})` : undefined,
                   backgroundPosition: 'center',


### PR DESCRIPTION
### Motivation
- Mobile certificate previews were clipping and overflowing in the Admin, Player, and Team dashboards due to switching to a `width: 100%` layout and insufficient padding/overflow handling when rendering the A4 landscape preview.

### Description
- Always render the preview from the fixed A4 base width and apply a uniform scale via `transform: scale(...)` instead of switching to `width: 100%`, to keep PDF export/print fidelity (`src/components/certificates/CertificatePreview.tsx`).
- Improve width measurement by adding an explicit `horizontalPadding` (different for mobile vs desktop) and a safer `safeViewportWidth` floor to avoid edge clipping during scale calculation.
- Add `overflow-x-hidden` to the preview wrapper and synchronize the wrapper height to the scaled `PREVIEW_BASE_HEIGHT` to prevent horizontal scroll and cropping.
- Normalize transform origin and transition to ensure consistent scale animation on resize across devices.

### Testing
- Ran `npm run build` which failed in this environment because `vite` is not available (`vite: not found`).
- Ran `npm ci` which failed due to `403 Forbidden` errors from the npm registry in this environment, so dependencies and a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d31fef488322aeeb2a078fa53d04)