### PR TITLE
Allow publishing schedules from any URL and embed Google Drive files

### DIFF
--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -14,6 +14,59 @@ import { useToast } from '@/hooks/use-toast';
 
 const SHEET_NAME = 'PUBLIC_SCHEDULES';
 
+function tryParseUrl(raw: string): URL | null {
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+function getGoogleDriveFileId(raw: string): string {
+  const url = tryParseUrl(raw);
+  if (!url) return '';
+  const host = url.hostname.replace(/^www\./, '');
+  if (!host.includes('google.com')) return '';
+
+  const fromQuery = url.searchParams.get('id');
+  if (fromQuery) return fromQuery;
+
+  const fileMatch = url.pathname.match(/\/file\/d\/([^/]+)/i);
+  if (fileMatch?.[1]) return fileMatch[1];
+
+  const docMatch = url.pathname.match(/\/(?:document|spreadsheets|presentation)\/d\/([^/]+)/i);
+  if (docMatch?.[1]) return docMatch[1];
+
+  return '';
+}
+
+function getGoogleEmbedUrl(raw: string): string {
+  const url = tryParseUrl(raw);
+  if (!url) return raw;
+  const host = url.hostname.replace(/^www\./, '');
+  const path = url.pathname;
+  const fileId = getGoogleDriveFileId(raw);
+
+  if (host === 'docs.google.com' && fileId && path.includes('/document/')) return `https://docs.google.com/document/d/${fileId}/preview`;
+  if (host === 'docs.google.com' && fileId && path.includes('/spreadsheets/')) return `https://docs.google.com/spreadsheets/d/${fileId}/preview`;
+  if (host === 'docs.google.com' && fileId && path.includes('/presentation/')) return `https://docs.google.com/presentation/d/${fileId}/embed`;
+  if (host === 'drive.google.com' && fileId) return `https://drive.google.com/file/d/${fileId}/preview`;
+
+  return raw;
+}
+
+function getScheduleEmbedUrl(raw: string): string {
+  const source = String(raw || '').trim();
+  if (!source) return '';
+  const parsed = tryParseUrl(source);
+  if (!parsed) return source;
+
+  const host = parsed.hostname.replace(/^www\./, '');
+  if (host.endsWith('google.com')) return getGoogleEmbedUrl(source);
+
+  return `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(source)}`;
+}
+
 const emptyForm = {
   title: '',
   tournament: '',
@@ -46,7 +99,7 @@ export default function SchedulesPage() {
   const createSchedule = async () => {
     if (!isAdmin) return;
     if (!form.title.trim() || !form.pdf_url.trim()) {
-      toast({ title: 'Title and PDF URL are required', variant: 'destructive' });
+      toast({ title: 'Title and file URL are required', variant: 'destructive' });
       return;
     }
     setSaving(true);
@@ -95,7 +148,7 @@ export default function SchedulesPage() {
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">
-              All published schedule PDFs are visible here to every visitor, including non-logged-in users.
+              All published schedule files are visible here to every visitor, including non-logged-in users.
             </p>
           </CardContent>
         </Card>
@@ -103,13 +156,13 @@ export default function SchedulesPage() {
         {isAdmin && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">Admin: Publish Schedule PDF</CardTitle>
+              <CardTitle className="text-base">Admin: Publish Schedule File</CardTitle>
             </CardHeader>
             <CardContent className="grid gap-3 md:grid-cols-2">
               <div><Label>Title</Label><Input value={form.title} onChange={(e) => setForm((p) => ({ ...p, title: e.target.value }))} placeholder="IPL 2026 Official Fixture" /></div>
               <div><Label>Tournament</Label><Input value={form.tournament} onChange={(e) => setForm((p) => ({ ...p, tournament: e.target.value }))} placeholder="IPL" /></div>
               <div><Label>Season</Label><Input value={form.season} onChange={(e) => setForm((p) => ({ ...p, season: e.target.value }))} placeholder="2026" /></div>
-              <div><Label>PDF URL</Label><Input value={form.pdf_url} onChange={(e) => setForm((p) => ({ ...p, pdf_url: e.target.value }))} placeholder="https://.../schedule.pdf" /></div>
+              <div><Label>File URL (PDF, DOC, Drive, etc.)</Label><Input value={form.pdf_url} onChange={(e) => setForm((p) => ({ ...p, pdf_url: e.target.value }))} placeholder="https://.../schedule.pdf" /></div>
               <div className="md:col-span-2">
                 <Button onClick={createSchedule} disabled={saving}><Plus className="mr-1 h-4 w-4" /> Publish schedule</Button>
               </div>
@@ -128,7 +181,7 @@ export default function SchedulesPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Badge variant="outline">Published</Badge>
-                    <Button asChild size="sm" variant="outline"><a href={item.pdf_url} target="_blank" rel="noreferrer"><Download className="mr-1 h-3.5 w-3.5" /> PDF</a></Button>
+                    <Button asChild size="sm" variant="outline"><a href={item.pdf_url} target="_blank" rel="noreferrer"><Download className="mr-1 h-3.5 w-3.5" /> Open file</a></Button>
                     {isAdmin && (
                       <Button size="sm" variant="destructive" onClick={() => void removeSchedule(item)}><Trash2 className="mr-1 h-3.5 w-3.5" /> Delete</Button>
                     )}
@@ -137,7 +190,7 @@ export default function SchedulesPage() {
               </CardHeader>
               <CardContent>
                 <div className="h-[68vh] w-full overflow-hidden rounded-lg border bg-muted/10">
-                  <iframe title={item.title} src={item.pdf_url} className="h-full w-full" />
+                  <iframe title={item.title} src={getScheduleEmbedUrl(item.pdf_url)} className="h-full w-full" />
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
### Motivation
- Admins should be able to publish schedules using any file URL (PDF, DOC, Drive links, etc.), not just PDF-labelled links. 
- Google Drive/Docs/Sheets/Slides links need to render correctly inside the schedules iframe so previews show as expected. 
- Provide a graceful fallback to render other remote file types inline for better UX across sources. 

### Description
- Added URL helpers: `tryParseUrl`, `getGoogleDriveFileId`, `getGoogleEmbedUrl`, and `getScheduleEmbedUrl` to normalize incoming URLs and produce embeddable preview URLs for Google Drive/Docs (src/pages/SchedulesPage.tsx). 
- Replaced direct `item.pdf_url` iframe usage with `getScheduleEmbedUrl(item.pdf_url)` so Google Drive/Docs/Sheets/Slides are shown via preview/embed and other URLs use Google Docs Viewer fallback. 
- Updated admin labels and validation text from “PDF URL”/“Title and PDF URL are required” to generic file wording (`File URL (PDF, DOC, Drive, etc.)` and `Title and file URL are required`) and changed the action link label from “PDF” to “Open file”. 
- Updated public copy to say “files” instead of “PDFs”. 

### Testing
- Attempted a local build with `npm run -s build`, which failed in this environment due to `vite` not being available (`sh: 1: vite: not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9defbc2608322978f31f468cb854b)