### PR TITLE
Redesign Documents Portal: add Google Drive folder browser and remove department UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,6 @@ const AdminWorkQueuePage = lazyWithRetry(() => import("./pages/AdminWorkQueuePag
 const TeamsDashboardPage = lazyWithRetry(() => import("./pages/TeamsDashboardPage"), "TeamsDashboardPage");
 const VerificationPage = lazyWithRetry(() => import("./pages/VerificationPage"), "VerificationPage");
 const FormsPortalPage = lazyWithRetry(() => import("./pages/FormsPortalPage"), "FormsPortalPage");
-const DepartmentDashboardPage = lazyWithRetry(() => import("./pages/DepartmentDashboardPage"), "DepartmentDashboardPage");
 const AdminOpsCenter = lazyWithRetry(() => import("./pages/AdminOpsCenter"), "AdminOpsCenter");
 const SchedulesPage = lazyWithRetry(() => import("./pages/SchedulesPage"), "SchedulesPage");
 
@@ -174,7 +173,6 @@ const App = () => (
                   <Route path="/verify" element={<VerificationPage />} />
                   <Route path="/verify/:type/:id" element={<VerificationPage />} />
                   <Route path="/forms" element={<RequireAuth><FormsPortalPage /></RequireAuth>} />
-                  <Route path="/departments/:department/dashboard" element={<RequireAuth><DepartmentDashboardPage /></RequireAuth>} />
                   <Route path="*" element={<NotFound />} />
                 </Routes>
               </Suspense>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,16 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { LogIn, LogOut, LayoutDashboard, Home, Trophy, Zap, Users, Shield, Database, Menu, Radio, Layers3, Crown, Newspaper, FolderLock, Search, FileText, BadgeCheck, ClipboardList, CalendarDays } from 'lucide-react';
 import { CommandPalette } from '@/components/CommandPalette';
-import { Logo, type LogoName } from '@/components/Logo';
-
-const departments: Array<{ label: string; logo: LogoName }> = [
-  { label: 'Cricket Operations', logo: 'cricket-operations' },
-  { label: 'Player Management', logo: 'player-management' },
-  { label: 'Match & Scoring', logo: 'match-scoring' },
-  { label: 'Certificates & Achievements', logo: 'certificates' },
-  { label: 'Community & Communication', logo: 'community' },
-  { label: 'System Administration', logo: 'admin' },
-];
+import { Logo } from '@/components/Logo';
 
 export function Navbar() {
   const { user, logout, isAdmin, isPlayer, isManagement, isTeam } = useAuth();
@@ -126,20 +117,6 @@ export function Navbar() {
               </Button>
             )}
           </>
-        )}
-
-        {mobile && (
-          <div className="mt-2 rounded-xl border bg-muted/25 p-2">
-            <p className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Departments</p>
-            <ul className="space-y-1">
-              {departments.map((department) => (
-                <li key={department.label} className="flex items-center text-xs text-foreground">
-                  <Logo name={department.logo} size={20} alt={`${department.label} Logo`} className="mr-2" lazy />
-                  {department.label}
-                </li>
-              ))}
-            </ul>
-          </div>
         )}
 
         {user && (

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -29,7 +29,6 @@ import { Logo } from '@/components/Logo';
 import { AdminForms } from '@/components/admin/AdminForms';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { DEPARTMENTS } from '@/lib/departmentManagement';
 
 const AdminDashboard = () => {
   const { isAdmin } = useAuth();
@@ -138,27 +137,6 @@ const AdminDashboard = () => {
               },
             ]}
           />
-        </div>
-
-        <div className="mb-6 rounded-2xl border border-primary/15 bg-card/80 p-4 sm:p-5">
-          <div className="mb-3 flex items-center justify-between gap-2">
-            <div>
-              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Department workspaces</p>
-              <h2 className="font-display text-lg font-semibold">Departments</h2>
-            </div>
-          </div>
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {DEPARTMENTS.map((department) => (
-              <div key={department.id} className="rounded-xl border border-border bg-background/80 p-4">
-                <p className="text-2xl" aria-hidden>{department.logo}</p>
-                <p className="mt-2 text-sm font-semibold text-foreground">{department.name}</p>
-                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{department.description}</p>
-                <Button asChild variant="outline" size="sm" className="mt-3 w-full">
-                  <Link to={`/departments/${department.slug}/dashboard`}>Open Department</Link>
-                </Button>
-              </div>
-            ))}
-          </div>
         </div>
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">

--- a/src/pages/DocumentsPortalPage.tsx
+++ b/src/pages/DocumentsPortalPage.tsx
@@ -16,14 +16,12 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/hooks/use-toast';
-import { FileText, Eye, Download, Sparkles, LockKeyhole, Building2, CalendarClock, ShieldCheck } from 'lucide-react';
+import { FileText, Eye, Download, Sparkles, LockKeyhole, CalendarClock, ShieldCheck, FolderSearch, Wand2 } from 'lucide-react';
 import { formatSheetDate } from '@/lib/dataUtils';
-import { DepartmentBadge } from '@/components/DepartmentBadge';
-import { DEPARTMENT_CATALOG, getDepartmentById, getDepartmentByName } from '@/lib/departmentCatalog';
 import { PageHeader } from '@/components/PageHeader';
 
 const categories = ['Governance', 'Tournament', 'Finance', 'Legal', 'Operations'] as const;
-const documentDepartmentOptions = DEPARTMENT_CATALOG.map((entry) => ({ id: entry.id, name: entry.name }));
+const DRIVE_FOLDER_STORAGE_KEY = 'documents_portal_drive_folder_url';
 
 const repoDocuments = import.meta.glob('../../docs/*.{pdf,PDF,doc,docx,txt,md}', {
   eager: true,
@@ -132,8 +130,8 @@ export default function DocumentsPortalPage() {
   const [docs, setDocs] = useState<OfficialDocumentRecord[]>([]);
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<(typeof categories)[number]>('Governance');
-  const [departmentId, setDepartmentId] = useState('executive_board');
   const [sourceUrl, setSourceUrl] = useState('');
+  const [driveFolderUrl, setDriveFolderUrl] = useState('');
   const [accessRuleMode, setAccessRuleMode] = useState<'all_management' | 'admin_only' | 'custom'>('all_management');
   const [selectedManagementIds, setSelectedManagementIds] = useState<string[]>([]);
   const [manualAccessTokens, setManualAccessTokens] = useState('');
@@ -167,6 +165,7 @@ export default function DocumentsPortalPage() {
     void refresh();
     void refreshSecurityProfiles();
     void refreshManagementUsers();
+    setDriveFolderUrl(localStorage.getItem(DRIVE_FOLDER_STORAGE_KEY) || '');
   }, []);
 
   const buildAccessList = () => {
@@ -189,8 +188,8 @@ export default function DocumentsPortalPage() {
           document_id: `REPO_${filename.replace(/[^a-zA-Z0-9]+/g, '_').toUpperCase()}`,
           title: titleText,
           category: 'Governance',
-          department_id: 'executive_board',
-          department: 'Executive Board',
+          department_id: '',
+          department: '',
           source_url: src,
           source_type: 'repository',
           status: 'published',
@@ -250,10 +249,19 @@ export default function DocumentsPortalPage() {
   const effectivePreviewAllowed = isAdmin ? securityProfile.allowPreview : managementPreviewAllowed;
   const effectiveDownloadAllowed = isAdmin ? (securityProfile.allowDownload && !securityProfile.viewOnly) : managementDownloadAllowed;
 
-  const resolveDocDepartmentId = (doc: OfficialDocumentRecord) => {
-    if (doc.department_id) return doc.department_id;
-    return getDepartmentByName(doc.department)?.id || 'general';
+  const extractDriveFolderId = (url: string) => {
+    const value = String(url || '').trim();
+    if (!value) return '';
+    const folderMatch = value.match(/\/folders\/([a-zA-Z0-9_-]+)/i);
+    if (folderMatch?.[1]) return folderMatch[1];
+    const idMatch = value.match(/[?&]id=([a-zA-Z0-9_-]+)/i);
+    return idMatch?.[1] || '';
   };
+
+  const driveFolderId = useMemo(() => extractDriveFolderId(driveFolderUrl), [driveFolderUrl]);
+  const embeddedDriveFolderUrl = driveFolderId
+    ? `https://drive.google.com/embeddedfolderview?id=${driveFolderId}#list`
+    : '';
 
   const loadProfileForDoc = (docId: string) => {
     const doc = mergedDocs.find((entry) => entry.document_id === docId);
@@ -388,8 +396,8 @@ export default function DocumentsPortalPage() {
       document_id: generateId('DOC'),
       title: title.trim(),
       category,
-      department_id: departmentId,
-      department: getDepartmentById(departmentId)?.name || 'General',
+      department_id: '',
+      department: '',
       source_url: sourceUrl.trim(),
       source_type: 'repository',
       status: 'published',
@@ -405,7 +413,7 @@ export default function DocumentsPortalPage() {
       toast({ title: 'Unable to save document policy', description: 'Please check OFFICIAL_DOCUMENTS sheet mapping.', variant: 'destructive' });
       return;
     }
-    logAudit(user?.username || 'admin', 'document_create', 'document', row.document_id, JSON.stringify({ category, department_id: row.department_id, allowed: row.allowed_management_ids }));
+    logAudit(user?.username || 'admin', 'document_create', 'document', row.document_id, JSON.stringify({ category, allowed: row.allowed_management_ids }));
     setTitle('');
     setSelectedManagementIds([]);
     setManualAccessTokens('');
@@ -442,7 +450,6 @@ export default function DocumentsPortalPage() {
     setEditingId(doc.document_id);
     setTitle(doc.title || '');
     setCategory((categories.includes(doc.category as (typeof categories)[number]) ? doc.category : 'Governance') as (typeof categories)[number]);
-    setDepartmentId(resolveDocDepartmentId(doc));
     setSourceUrl(doc.source_url || '');
     const tokens = String(doc.allowed_management_ids || 'all_management').split(',').map((token) => token.trim()).filter(Boolean);
     if (tokens.includes('all_management') || tokens.length === 0) {
@@ -467,7 +474,6 @@ export default function DocumentsPortalPage() {
     setEditingId('');
     setTitle('');
     setCategory('Governance');
-    setDepartmentId('executive_board');
     setSourceUrl('');
     setAccessRuleMode('all_management');
     setSelectedManagementIds([]);
@@ -491,8 +497,8 @@ export default function DocumentsPortalPage() {
       ...(existing || baseDoc),
       title: title.trim(),
       category,
-      department_id: departmentId,
-      department: getDepartmentById(departmentId)?.name || 'General',
+      department_id: '',
+      department: '',
       allowed_management_ids: buildAccessList() || 'all_management',
       source_url: sourceUrl.trim(),
       updated_at: new Date().toISOString(),
@@ -504,7 +510,7 @@ export default function DocumentsPortalPage() {
       toast({ title: 'Unable to update document', variant: 'destructive' });
       return;
     }
-    logAudit(user?.username || 'admin', 'document_update', 'document', payload.document_id, JSON.stringify({ category: payload.category, department_id: payload.department_id, allowed: payload.allowed_management_ids }));
+    logAudit(user?.username || 'admin', 'document_update', 'document', payload.document_id, JSON.stringify({ category: payload.category, allowed: payload.allowed_management_ids }));
     toast({ title: 'Document updated' });
     clearEditor();
     refresh();
@@ -632,11 +638,42 @@ export default function DocumentsPortalPage() {
                 <Badge variant="outline" className="bg-background/80">Visible for admin: {visibleDocs.length}</Badge>
                 <Badge variant="outline" className="bg-background/80">Strict admin only: Enabled</Badge>
               </div>
-              <p className="text-sm text-muted-foreground">All documents are loaded from the repository <code>/docs</code> folder. Admin can apply granular security controls per document profile.</p>
+              <p className="text-sm text-muted-foreground">A beautiful, responsive document workspace for mobile, tablet, and desktop. Ask an admin to share a Google Drive folder URL to unlock instant file browsing.</p>
             </CardContent>
           </Card>
           <VerticalAnnouncementsBox />
         </div>
+
+        <Card className="border-primary/30 bg-gradient-to-br from-background via-primary/5 to-accent/10">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base"><FolderSearch className="h-4 w-4 text-primary" />Google Drive Folder View</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">Ask admin to share the Google Drive folder URL. Once added, all users with portal access can browse files directly here.</p>
+            {isAdmin && (
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input value={driveFolderUrl} onChange={(e) => setDriveFolderUrl(e.target.value)} placeholder="https://drive.google.com/drive/folders/..." />
+                <Button
+                  type="button"
+                  onClick={() => {
+                    localStorage.setItem(DRIVE_FOLDER_STORAGE_KEY, driveFolderUrl.trim());
+                    toast({ title: 'Drive folder saved', description: 'Shared folder URL has been stored for this browser session.' });
+                  }}
+                >
+                  <Wand2 className="mr-1 h-4 w-4" />Save URL
+                </Button>
+              </div>
+            )}
+            {!isAdmin && !driveFolderId && <p className="text-xs text-muted-foreground">No shared Drive folder URL yet. Please ask an admin to add it.</p>}
+            {embeddedDriveFolderUrl ? (
+              <div className="overflow-hidden rounded-xl border">
+                <iframe title="Google Drive folder files" src={embeddedDriveFolderUrl} className="w-full" style={{ minHeight: 420, height: 'min(72vh, 640px)' }} />
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">Paste a valid Google Drive folder URL to display files here.</div>
+            )}
+          </CardContent>
+        </Card>
 
         <Card className="border-primary/30 bg-gradient-to-br from-primary/10 via-background to-accent/10">
           <CardHeader className="pb-3">
@@ -647,10 +684,6 @@ export default function DocumentsPortalPage() {
               {latestVisibleDocs.map((doc) => (
                 <div key={`scroll-${doc.document_id}`} className="min-w-[280px] rounded-xl border border-primary/20 bg-background/80 p-3 shadow-sm">
                   <p className="line-clamp-2 text-sm font-semibold">{doc.title}</p>
-                  <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-                    <Building2 className="h-3.5 w-3.5" />
-                    <DepartmentBadge department={doc.department} departmentId={resolveDocDepartmentId(doc)} className="h-6 px-2 py-0 text-[10px]" />
-                  </div>
                   <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
                     <CalendarClock className="h-3.5 w-3.5" /> Updated {formatSheetDate(doc.updated_at, 'dd MMM yyyy', doc.updated_at)}
                   </div>
@@ -676,7 +709,6 @@ export default function DocumentsPortalPage() {
             <CardContent className="grid gap-3 md:grid-cols-3">
               <div className="md:col-span-2"><Label>Title</Label><Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Board circular / policy / schedule" /></div>
               <div><Label>Category</Label><Select value={category} onValueChange={(v) => setCategory(v as (typeof categories)[number])}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{categories.map((item) => <SelectItem value={item} key={item}>{item}</SelectItem>)}</SelectContent></Select></div>
-              <div><Label>Department</Label><Select value={departmentId} onValueChange={setDepartmentId}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{documentDepartmentOptions.map((option) => <SelectItem value={option.id} key={option.id}>{option.name}</SelectItem>)}</SelectContent></Select></div>
               <div className="md:col-span-2"><Label>Source URL (required for preview)</Label><Input value={sourceUrl} onChange={(e) => setSourceUrl(e.target.value)} placeholder="/docs/ICC 2017.pdf or https://..." /></div>
               <div>
                 <Label>Access Mode</Label>
@@ -738,7 +770,6 @@ export default function DocumentsPortalPage() {
                   <div className="flex items-center justify-between gap-2">
                     <div>
                       <p className="font-semibold flex items-center gap-2"><Sparkles className="h-4 w-4 text-primary" /> {doc.title}</p>
-                      <div className="mt-1"><DepartmentBadge department={doc.department} departmentId={resolveDocDepartmentId(doc)} className="text-[10px]" /></div>
                     </div>
                     <Badge variant={doc.status === 'published' ? 'default' : 'secondary'}>{doc.status}</Badge>
                   </div>

--- a/src/pages/ManagementPage.tsx
+++ b/src/pages/ManagementPage.tsx
@@ -175,22 +175,6 @@ const ManagementPage = () => {
     });
   }, [searchQuery, designationFilter, boardMembers]);
 
-  const departmentDirectory = useMemo(() => {
-    const assignments = parseDepartmentAssignments(boardConfig);
-    return BOARD_DEPARTMENTS.map((department) => {
-      const assignment = assignments.find((item) => item.department_id === department.id);
-      const head = users.find((member) => member.management_id === assignment?.head_id);
-      const team = (assignment?.team_ids || [])
-        .map((id) => users.find((member) => member.management_id === id))
-        .filter((member): member is ManagementUser => Boolean(member));
-      return {
-        ...department,
-        headName: head?.name || 'Not assigned',
-        teamNames: team.map((member) => member.name || member.management_id),
-      };
-    });
-  }, [boardConfig, users]);
-
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
@@ -258,25 +242,6 @@ const ManagementPage = () => {
                 </Button>
               </div>
             ))}
-          </CardContent>
-        </Card>
-
-        <Card className="border-accent/20">
-          <CardHeader>
-            <CardTitle className="font-display text-lg sm:text-xl">🏢 Department Directory</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {departmentDirectory.map((department) => (
-                <div key={department.id} className="rounded-xl border bg-muted/20 p-3">
-                  <p className="font-semibold text-sm">{department.name}</p>
-                  <p className="text-xs text-muted-foreground mt-1">Head: {department.headName}</p>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Members: {department.teamNames.length ? department.teamNames.join(', ') : 'No members assigned'}
-                  </p>
-                </div>
-              ))}
-            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
### Motivation
- Provide a cleaner, responsive Documents Portal UI that supports browsing a shared Google Drive folder and modernizes the document workspace across mobile/tablet/desktop.
- Remove departments from the Documents experience and from other admin/management surfaces to simplify policy metadata and navigation.

### Description
- Added a Google Drive Folder View to the Documents Portal with a persisted URL stored in `localStorage` under `documents_portal_drive_folder_url`, Drive folder ID extraction, and an embedded folder iframe for browsing (changes in `src/pages/DocumentsPortalPage.tsx`).
- Removed department-related metadata and UI from the Documents Portal: department selection in the add/edit policy form, `DepartmentBadge` usage on cards, and default department values are now neutral/empty; audit payloads were simplified to omit department fields (changes in `src/pages/DocumentsPortalPage.tsx`).
- Removed department entry points across the app by deleting the departments mobile list from the navbar, removing the departments route, and removing department workspace/directory cards from admin and management pages (changes in `src/components/Navbar.tsx`, `src/App.tsx`, `src/pages/AdminDashboard.tsx`, and `src/pages/ManagementPage.tsx`).
- Minor UI polish: new icons imported for the Drive block and small text updates to describe the Drive workflow.

### Testing
- Attempted `npm run build`, but the build step failed in this environment because `vite` is not available (`vite: not found`).
- Attempted `npm ci`, but dependency installation failed due to network/registry restrictions (`npm` returned `403 Forbidden`).
- No automated test suite was executed successfully in this environment due to the above package installation/build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9dea415988322b803a34b9a98f0e5)