### PR TITLE
Add branded page logos and tournament logo lockup

### DIFF
--- a/public/assets/logos/documents-vault.svg
+++ b/public/assets/logos/documents-vault.svg
@@ -1,0 +1,16 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Documents Vault Logo</title>
+  <desc id="desc">Secure documents portal logo.</desc>
+  <defs>
+    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#0f766e"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#ecfeff"/>
+  <rect x="82" y="72" width="156" height="188" rx="18" fill="url(#g2)"/>
+  <rect x="106" y="110" width="108" height="12" rx="6" fill="white"/>
+  <rect x="106" y="140" width="108" height="12" rx="6" fill="white" opacity="0.9"/>
+  <rect x="106" y="170" width="72" height="12" rx="6" fill="white" opacity="0.8"/>
+  <path d="M205 224l-20-20-20 20v-44h40v44z" fill="#99f6e4"/>
+</svg>

--- a/public/assets/logos/hall-of-glory.svg
+++ b/public/assets/logos/hall-of-glory.svg
@@ -1,0 +1,14 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Hall of Glory Logo</title>
+  <desc id="desc">Champions hall icon.</desc>
+  <defs>
+    <linearGradient id="g6" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#f5f3ff"/>
+  <circle cx="160" cy="134" r="56" fill="url(#g6)"/>
+  <path d="M126 134l20 20 48-48" stroke="white" stroke-width="14" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="108" y="206" width="104" height="28" rx="12" fill="#7c3aed"/>
+</svg>

--- a/public/assets/logos/leaderboards-elite.svg
+++ b/public/assets/logos/leaderboards-elite.svg
@@ -1,0 +1,16 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Leaderboards Elite Logo</title>
+  <desc id="desc">Trophy rankings logo.</desc>
+  <defs>
+    <linearGradient id="g4" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#15803d"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#f0fdf4"/>
+  <path d="M115 86h90v26c0 35-23 61-45 70-22-9-45-35-45-70V86z" fill="url(#g4)"/>
+  <rect x="142" y="182" width="36" height="24" rx="8" fill="#166534"/>
+  <rect x="126" y="206" width="68" height="24" rx="10" fill="#15803d"/>
+  <circle cx="96" cy="110" r="20" fill="#86efac"/>
+  <circle cx="224" cy="110" r="20" fill="#86efac"/>
+</svg>

--- a/public/assets/logos/management-hub.svg
+++ b/public/assets/logos/management-hub.svg
@@ -1,0 +1,14 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Board Management Hub Logo</title>
+  <desc id="desc">Shield-inspired executive board logo.</desc>
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#eff6ff"/>
+  <path d="M160 66l78 28v50c0 58-36 94-78 112-42-18-78-54-78-112V94l78-28z" fill="url(#g1)"/>
+  <path d="M122 144h76M122 172h76" stroke="white" stroke-width="12" stroke-linecap="round"/>
+  <circle cx="160" cy="112" r="16" fill="white"/>
+</svg>

--- a/public/assets/logos/match-center-live.svg
+++ b/public/assets/logos/match-center-live.svg
@@ -1,0 +1,15 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Match Center Live Logo</title>
+  <desc id="desc">Live scoring operations logo.</desc>
+  <defs>
+    <linearGradient id="g5" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f43f5e"/>
+      <stop offset="100%" stop-color="#be123c"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#fff1f2"/>
+  <rect x="72" y="92" width="176" height="136" rx="24" fill="url(#g5)"/>
+  <circle cx="116" cy="160" r="18" fill="#ffe4e6"/>
+  <rect x="150" y="148" width="70" height="24" rx="12" fill="#ffe4e6"/>
+  <rect x="98" y="238" width="124" height="16" rx="8" fill="#be123c"/>
+</svg>

--- a/public/assets/logos/news-room-wire.svg
+++ b/public/assets/logos/news-room-wire.svg
@@ -1,0 +1,17 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">News Room Wire Logo</title>
+  <desc id="desc">News and media bulletin logo.</desc>
+  <defs>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#fff7ed"/>
+  <rect x="66" y="86" width="188" height="148" rx="24" fill="url(#g3)"/>
+  <rect x="94" y="114" width="132" height="14" rx="7" fill="white"/>
+  <rect x="94" y="144" width="132" height="14" rx="7" fill="white" opacity="0.9"/>
+  <rect x="94" y="174" width="96" height="14" rx="7" fill="white" opacity="0.8"/>
+  <circle cx="222" cy="212" r="18" fill="#7c2d12"/>
+  <path d="M214 212l6 6 12-12" stroke="white" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/logos/tournament-cup.svg
+++ b/public/assets/logos/tournament-cup.svg
@@ -1,0 +1,16 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Tournament Cup Logo</title>
+  <desc id="desc">Tournament identity mark.</desc>
+  <defs>
+    <linearGradient id="g7" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#0369a1"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="272" height="272" rx="56" fill="#ecfeff"/>
+  <path d="M120 82h80v20c0 35-20 60-40 72-20-12-40-37-40-72V82z" fill="url(#g7)"/>
+  <rect x="144" y="174" width="32" height="22" rx="7" fill="#0284c7"/>
+  <rect x="126" y="198" width="68" height="22" rx="8" fill="#0e7490"/>
+  <path d="M105 98H84c0 24 9 39 27 47" stroke="#06b6d4" stroke-width="10" fill="none" stroke-linecap="round"/>
+  <path d="M215 98h21c0 24-9 39-27 47" stroke="#06b6d4" stroke-width="10" fill="none" stroke-linecap="round"/>
+</svg>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -7,7 +7,14 @@ export type LogoName =
   | 'match-scoring'
   | 'certificates'
   | 'community'
-  | 'admin';
+  | 'admin'
+  | 'management-hub'
+  | 'documents-vault'
+  | 'news-room-wire'
+  | 'leaderboards-elite'
+  | 'match-center-live'
+  | 'hall-of-glory'
+  | 'tournament-cup';
 
 interface LogoProps {
   name: LogoName;
@@ -25,6 +32,13 @@ const logoSrcByName: Record<LogoName, string> = {
   certificates: '/assets/logos/certificates.svg',
   community: '/assets/logos/community.svg',
   admin: '/assets/logos/admin.svg',
+  'management-hub': '/assets/logos/management-hub.svg',
+  'documents-vault': '/assets/logos/documents-vault.svg',
+  'news-room-wire': '/assets/logos/news-room-wire.svg',
+  'leaderboards-elite': '/assets/logos/leaderboards-elite.svg',
+  'match-center-live': '/assets/logos/match-center-live.svg',
+  'hall-of-glory': '/assets/logos/hall-of-glory.svg',
+  'tournament-cup': '/assets/logos/tournament-cup.svg',
 };
 
 const logoAltByName: Record<LogoName, string> = {
@@ -35,6 +49,13 @@ const logoAltByName: Record<LogoName, string> = {
   certificates: 'Certificates and Achievements Logo',
   community: 'Community and Communication Logo',
   admin: 'System Administration Logo',
+  'management-hub': 'Board Management Hub Logo',
+  'documents-vault': 'Documents Portal Vault Logo',
+  'news-room-wire': 'News Room Wire Logo',
+  'leaderboards-elite': 'Leaderboards Elite Logo',
+  'match-center-live': 'Match Center Live Logo',
+  'hall-of-glory': 'Hall of Glory Logo',
+  'tournament-cup': 'Tournament Cup Logo',
 };
 
 export function Logo({ name, size = 24, className, alt, lazy = false }: LogoProps) {

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -25,7 +25,7 @@ export function PageHeader({ route, title, subtitle, className }: PageHeaderProp
   const Icon = meta?.icon;
   const resolvedTitle = title || meta?.title || 'Page';
   const resolvedSubtitle = subtitle || meta?.subtitle;
-  const logoName = departmentLogoById[meta?.departmentId || ''] || 'main-logo';
+  const logoName = meta?.logoName || departmentLogoById[meta?.departmentId || ''] || 'main-logo';
 
   return (
     <div className={className}>

--- a/src/components/TournamentLogoLockup.tsx
+++ b/src/components/TournamentLogoLockup.tsx
@@ -1,0 +1,22 @@
+import { Logo } from '@/components/Logo';
+import { getTournamentBranding } from '@/lib/tournamentBranding';
+
+interface TournamentLogoLockupProps {
+  tournamentName: string;
+}
+
+export function TournamentLogoLockup({ tournamentName }: TournamentLogoLockupProps) {
+  const branding = getTournamentBranding(tournamentName);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <Logo name="tournament-cup" alt={`${tournamentName} tournament logo`} className="h-14 w-14 md:h-16 md:w-16" />
+        <div className={`h-14 w-14 md:h-16 md:w-16 rounded-2xl bg-gradient-to-br ${branding.accentClass} text-white flex items-center justify-center font-display text-xl md:text-2xl font-black shadow-sm`}>
+          {branding.shortCode}
+        </div>
+      </div>
+      <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">{branding.tagline}</p>
+    </div>
+  );
+}

--- a/src/lib/pageBranding.ts
+++ b/src/lib/pageBranding.ts
@@ -1,3 +1,4 @@
+import { type LogoName } from '@/components/Logo';
 import { type LucideIcon, FileText, Newspaper, ShieldCheck, Trophy, Users, Zap } from 'lucide-react';
 
 export interface PageBranding {
@@ -7,6 +8,7 @@ export interface PageBranding {
   emoji?: string;
   icon?: LucideIcon;
   departmentId?: string;
+  logoName?: LogoName;
 }
 
 export const PAGE_BRANDING: Record<string, PageBranding> = {
@@ -17,6 +19,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '👑',
     departmentId: 'executive_board',
     icon: Users,
+    logoName: 'management-hub',
   },
   '/documents-portal': {
     route: '/documents-portal',
@@ -25,6 +28,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '🛡️',
     departmentId: 'governance',
     icon: FileText,
+    logoName: 'documents-vault',
   },
   '/news-room': {
     route: '/news-room',
@@ -33,6 +37,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '📰',
     departmentId: 'media_community',
     icon: Newspaper,
+    logoName: 'news-room-wire',
   },
   '/leaderboards': {
     route: '/leaderboards',
@@ -41,6 +46,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '🏆',
     departmentId: 'competition_operations',
     icon: Trophy,
+    logoName: 'leaderboards-elite',
   },
   '/admin/match-center': {
     route: '/admin/match-center',
@@ -49,6 +55,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '🏏',
     departmentId: 'competition_operations',
     icon: Zap,
+    logoName: 'match-center-live',
   },
   '/hall-of-glory': {
     route: '/hall-of-glory',
@@ -57,6 +64,7 @@ export const PAGE_BRANDING: Record<string, PageBranding> = {
     emoji: '🏆',
     departmentId: 'tournament',
     icon: ShieldCheck,
+    logoName: 'hall-of-glory',
   },
 };
 

--- a/src/lib/tournamentBranding.ts
+++ b/src/lib/tournamentBranding.ts
@@ -1,0 +1,35 @@
+export interface TournamentBranding {
+  shortCode: string;
+  tagline: string;
+  accentClass: string;
+}
+
+function initialsFromName(name: string): string {
+  const tokens = name
+    .split(/[^A-Za-z0-9]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  if (tokens.length === 0) return 'TRN';
+  if (tokens.length === 1) return tokens[0].slice(0, 3).toUpperCase();
+
+  return tokens.slice(0, 3).map((token) => token[0]?.toUpperCase() ?? '').join('');
+}
+
+export function getTournamentBranding(name: string): TournamentBranding {
+  const normalized = name.toLowerCase();
+
+  if (normalized.includes('premier')) {
+    return { shortCode: initialsFromName(name), tagline: 'Premier Tournament Series', accentClass: 'from-indigo-500 to-blue-600' };
+  }
+
+  if (normalized.includes('cup')) {
+    return { shortCode: initialsFromName(name), tagline: 'Championship Cup', accentClass: 'from-cyan-500 to-sky-600' };
+  }
+
+  if (normalized.includes('league')) {
+    return { shortCode: initialsFromName(name), tagline: 'Elite League Competition', accentClass: 'from-emerald-500 to-teal-600' };
+  }
+
+  return { shortCode: initialsFromName(name), tagline: 'Official Tournament Event', accentClass: 'from-primary to-accent' };
+}

--- a/src/pages/TournamentPage.tsx
+++ b/src/pages/TournamentPage.tsx
@@ -6,12 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, Trophy, Calendar, MapPin, Users, Shield, ExternalLink, Medal, BarChart3 } from 'lucide-react';
+import { ArrowLeft, Calendar, MapPin, Users, Shield, ExternalLink, Medal, BarChart3 } from 'lucide-react';
 import { v2api } from '@/lib/v2api';
 import { DigitalScorelist } from '@/lib/v2types';
 import { SecurityShieldBadge, DataIntegrityBadge, SecurityWatermark } from '@/components/SecurityBadge';
 import { PageLoader } from '@/components/LoadingOverlay';
 import { compareSheetDatesDesc, findTournamentById, formatSheetDate, hasSheetDate, normalizeId } from '@/lib/dataUtils';
+import { TournamentLogoLockup } from '@/components/TournamentLogoLockup';
 
 const TournamentPage = () => {
   const { id } = useParams();
@@ -107,8 +108,8 @@ const TournamentPage = () => {
         <Card className="border-2 border-primary/20 bg-gradient-to-br from-primary/5 via-accent/5 to-transparent overflow-hidden">
           <CardContent className="p-6 md:p-8">
             <div className="flex flex-col md:flex-row items-start gap-4">
-              <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-primary to-accent flex items-center justify-center shrink-0">
-                <Trophy className="h-8 w-8 text-primary-foreground" />
+              <div className="shrink-0">
+                <TournamentLogoLockup tournamentName={tournament.name} />
               </div>
               <div className="flex-1">
                 <h1 className="font-display text-3xl md:text-4xl font-bold">{tournament.name}</h1>


### PR DESCRIPTION
### Motivation
- Introduce distinct visual identities for major pages and tournaments so each route/tournament can surface a tailored logo and lockup in the UI. 
- Provide a reusable tournament branding lockup that can generate shortcodes and taglines from tournament names for consistent presentation across pages.

### Description
- Added a set of SVG logo assets under `public/assets/logos/` for Management, Documents Portal, News Room, Leaderboards, Match Center, Hall of Glory and a Tournament emblem. 
- Extended the `Logo` component to register the new logo variants and provide matching `alt` text. 
- Added a `logoName` field to page branding metadata (`src/lib/pageBranding.ts`) and updated `PageHeader` to prefer a route-specific `logoName` over the department fallback. 
- Created `src/lib/tournamentBranding.ts` to derive tournament shortcodes, taglines and accent classes and added `src/components/TournamentLogoLockup.tsx` to render the tournament emblem + shortcode lockup. 
- Replaced the generic icon in the tournament hero with the new `TournamentLogoLockup` on the Tournament page so each tournament page shows a branded header.

### Testing
- Attempted `npm run build`, which failed in this environment because `vite` is not available (`vite: not found`).
- Attempted `npm ci`, which failed due to `package.json` and `package-lock.json` being out of sync in this environment (lock/dependency mismatch). 
- Attempted `npm install` but dependency install could not be completed reliably in this environment, so no full build or test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30a275b98832c93d8f20da7f1dac3)