### PR TITLE
Improve scheduler generation and surface certified fixtures on public schedules

### DIFF
--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -11,6 +11,8 @@ import { PublicScheduleRecord } from '@/lib/v2types';
 import { generateId } from '@/lib/utils';
 import { Download, FileText, Globe, Plus, Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { ScheduleMatch, ScheduleRecord } from '@/schedules/types';
+import { formatScheduleSlotInIST } from '@/lib/time';
 
 const SHEET_NAME = 'PUBLIC_SCHEDULES';
 
@@ -74,19 +76,39 @@ const emptyForm = {
   pdf_url: '',
 };
 
+interface PublishedMatchSchedule {
+  id: string;
+  title: string;
+  tournament: string;
+  season: string;
+  source: 'manual_file' | 'governance_release';
+  fileUrl?: string;
+  publishedAt: string;
+  matches: ScheduleMatch[];
+}
+
 export default function SchedulesPage() {
   const { isAdmin, user } = useAuth();
   const { toast } = useToast();
   const [rows, setRows] = useState<PublicScheduleRecord[]>([]);
+  const [governanceSchedules, setGovernanceSchedules] = useState<ScheduleRecord[]>([]);
   const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
 
   const refresh = async () => {
-    const data = await v2api.getCustomSheet<PublicScheduleRecord>(SHEET_NAME);
+    const [data, certified] = await Promise.all([
+      v2api.getCustomSheet<PublicScheduleRecord>(SHEET_NAME),
+      v2api.getCustomSheet<ScheduleRecord>('schedules'),
+    ]);
     setRows(
       data
         .filter((item) => item.schedule_id && item.pdf_url)
         .sort((a, b) => (b.published_at || b.updated_at || '').localeCompare(a.published_at || a.updated_at || '')),
+    );
+    setGovernanceSchedules(
+      certified
+        .filter((item) => item.schedule_id && item.status === 'approved' && item.matches_json)
+        .sort((a, b) => (b.certified_at || b.timestamp || '').localeCompare(a.certified_at || a.timestamp || '')),
     );
   };
 
@@ -94,7 +116,40 @@ export default function SchedulesPage() {
     void refresh();
   }, []);
 
-  const publishedSchedules = useMemo(() => rows.filter((item) => String(item.status || '').toLowerCase() === 'published'), [rows]);
+  const publishedSchedules = useMemo<PublishedMatchSchedule[]>(() => {
+    const manual = rows
+      .filter((item) => String(item.status || '').toLowerCase() === 'published')
+      .map((item) => ({
+        id: item.schedule_id,
+        title: item.title,
+        tournament: item.tournament || 'General',
+        season: item.season || '',
+        source: 'manual_file' as const,
+        fileUrl: item.pdf_url,
+        publishedAt: item.published_at || item.updated_at || '',
+        matches: [],
+      }));
+
+    const governance = governanceSchedules.map((item) => {
+      let matches: ScheduleMatch[] = [];
+      try {
+        matches = JSON.parse(item.matches_json) as ScheduleMatch[];
+      } catch {
+        matches = [];
+      }
+      return {
+        id: `${item.schedule_id}:fixture`,
+        title: `${item.tournament_name} · Official Fixture (v${item.version_number})`,
+        tournament: item.tournament_name,
+        season: item.timestamp?.slice(0, 4) || '',
+        source: 'governance_release' as const,
+        publishedAt: item.certified_at || item.timestamp || '',
+        matches,
+      };
+    });
+
+    return [...governance, ...manual].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  }, [rows, governanceSchedules]);
 
   const createSchedule = async () => {
     if (!isAdmin) return;
@@ -127,9 +182,9 @@ export default function SchedulesPage() {
     toast({ title: 'Schedule published' });
   };
 
-  const removeSchedule = async (row: PublicScheduleRecord) => {
+  const removeSchedule = async (scheduleId: string) => {
     if (!isAdmin) return;
-    const ok = await v2api.deleteCustomSheetRow(SHEET_NAME, { schedule_id: row.schedule_id });
+    const ok = await v2api.deleteCustomSheetRow(SHEET_NAME, { schedule_id: scheduleId });
     if (!ok) {
       toast({ title: 'Unable to delete schedule', variant: 'destructive' });
       return;
@@ -172,7 +227,7 @@ export default function SchedulesPage() {
 
         <div className="space-y-4">
           {publishedSchedules.map((item) => (
-            <Card key={item.schedule_id} className="overflow-hidden">
+            <Card key={item.id} className="overflow-hidden">
               <CardHeader className="pb-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
@@ -181,17 +236,48 @@ export default function SchedulesPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Badge variant="outline">Published</Badge>
-                    <Button asChild size="sm" variant="outline"><a href={item.pdf_url} target="_blank" rel="noreferrer"><Download className="mr-1 h-3.5 w-3.5" /> Open file</a></Button>
-                    {isAdmin && (
-                      <Button size="sm" variant="destructive" onClick={() => void removeSchedule(item)}><Trash2 className="mr-1 h-3.5 w-3.5" /> Delete</Button>
+                    <Badge variant={item.source === 'governance_release' ? 'default' : 'secondary'}>
+                      {item.source === 'governance_release' ? 'Season release' : 'Uploaded file'}
+                    </Badge>
+                    {item.fileUrl && <Button asChild size="sm" variant="outline"><a href={item.fileUrl} target="_blank" rel="noreferrer"><Download className="mr-1 h-3.5 w-3.5" /> Open file</a></Button>}
+                    {isAdmin && item.source === 'manual_file' && (
+                      <Button size="sm" variant="destructive" onClick={() => void removeSchedule(item.id)}><Trash2 className="mr-1 h-3.5 w-3.5" /> Delete</Button>
                     )}
                   </div>
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="h-[68vh] w-full overflow-hidden rounded-lg border bg-muted/10">
-                  <iframe title={item.title} src={getScheduleEmbedUrl(item.pdf_url)} className="h-full w-full" />
-                </div>
+                {item.fileUrl ? (
+                  <div className="h-[68vh] w-full overflow-hidden rounded-lg border bg-muted/10">
+                    <iframe title={item.title} src={getScheduleEmbedUrl(item.fileUrl)} className="h-full w-full" />
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <p className="text-sm text-muted-foreground">Official season fixture generated from the governance scheduler and released after certification.</p>
+                    <div className="max-h-[55vh] overflow-auto rounded-lg border">
+                      <table className="w-full text-sm">
+                        <thead className="sticky top-0 bg-muted/50">
+                          <tr>
+                            <th className="px-3 py-2 text-left font-medium">Slot (IST)</th>
+                            <th className="px-3 py-2 text-left font-medium">Match</th>
+                            <th className="px-3 py-2 text-left font-medium">Venue</th>
+                            <th className="px-3 py-2 text-left font-medium">Stage</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {item.matches.map((match) => (
+                            <tr key={match.match_id} className="border-t">
+                              <td className="px-3 py-2 whitespace-nowrap">{formatScheduleSlotInIST(match.date, match.time)}</td>
+                              <td className="px-3 py-2">{match.team_a} vs {match.team_b}</td>
+                              <td className="px-3 py-2">{match.venue}</td>
+                              <td className="px-3 py-2">{match.stage}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
               </CardContent>
             </Card>
           ))}

--- a/src/schedules/scheduleGenerator.ts
+++ b/src/schedules/scheduleGenerator.ts
@@ -10,6 +10,8 @@ interface GeneratorInput {
 interface TeamAvailability {
   lastDayPlayed?: string;
   dayCounts: Record<string, number>;
+  totalMatches: number;
+  venues: Record<string, number>;
 }
 
 const stageLabelByFormat: Record<ScheduleFormat, string> = {
@@ -43,28 +45,63 @@ function combinations(teams: string[]) {
   return pairs;
 }
 
-function matchesByFormat(format: ScheduleFormat, teams: string[]) {
-  if (format === 'round_robin') return combinations(teams);
-  if (format === 'double_round_robin') {
-    const firstLeg = combinations(teams);
-    const secondLeg = firstLeg.map(([a, b]) => [b, a] as [string, string]);
-    return [...firstLeg, ...secondLeg];
+function rotateForRoundRobin(teams: string[]) {
+  if (teams.length <= 2) return teams;
+  const fixed = teams[0];
+  const rotating = teams.slice(1);
+  const last = rotating.pop();
+  if (!last) return teams;
+  rotating.unshift(last);
+  return [fixed, ...rotating];
+}
+
+function roundRobinMatches(teams: string[], doubleLeg: boolean) {
+  const normalized = teams.length % 2 === 0 ? [...teams] : [...teams, 'BYE'];
+  const rounds = normalized.length - 1;
+  let rotation = [...normalized];
+  const matches: Array<[string, string]> = [];
+
+  for (let round = 0; round < rounds; round += 1) {
+    for (let i = 0; i < rotation.length / 2; i += 1) {
+      const home = rotation[i];
+      const away = rotation[rotation.length - 1 - i];
+      if (home === 'BYE' || away === 'BYE') continue;
+      const shouldSwap = round % 2 === 1;
+      matches.push(shouldSwap ? [away, home] : [home, away]);
+    }
+    rotation = rotateForRoundRobin(rotation);
   }
 
-  if (format === 'single_elimination') {
-    const seeded = [...teams];
-    const out: Array<[string, string]> = [];
+  if (!doubleLeg) return matches;
+  return [...matches, ...matches.map(([a, b]) => [b, a] as [string, string])];
+}
+
+function eliminationMatches(teams: string[]) {
+  let seeded = [...teams];
+  const output: Array<[string, string]> = [];
+
+  while (seeded.length > 1) {
+    const roundPairs: Array<[string, string]> = [];
+    const winnerPlaceholders: string[] = [];
     while (seeded.length > 1) {
       const home = seeded.shift()!;
       const away = seeded.pop()!;
-      out.push([home, away]);
+      roundPairs.push([home, away]);
+      winnerPlaceholders.push(`Winner of ${home} vs ${away}`);
     }
-    return out;
+    if (seeded.length === 1) winnerPlaceholders.push(seeded[0]);
+    output.push(...roundPairs);
+    seeded = winnerPlaceholders;
   }
 
-  const primary = combinations(teams);
-  const reversed = primary.map(([a, b]) => [b, a] as [string, string]);
-  return [...primary, ...reversed];
+  return output;
+}
+
+function matchesByFormat(format: ScheduleFormat, teams: string[]) {
+  if (format === 'round_robin') return roundRobinMatches(teams, false);
+  if (format === 'double_round_robin') return roundRobinMatches(teams, true);
+  if (format === 'single_elimination') return eliminationMatches(teams);
+  return [...eliminationMatches(teams), ...combinations(teams)];
 }
 
 function canPlace(
@@ -77,7 +114,7 @@ function canPlace(
 ) {
   const teams = [teamA, teamB];
   return teams.every((team) => {
-    const state = availability[team] || { dayCounts: {} };
+    const state = availability[team] || { dayCounts: {}, totalMatches: 0, venues: {} };
     const dayCount = state.dayCounts[day] || 0;
     if (!allowSameDayMultipleMatches && dayCount >= 1) return false;
     if (!allowConsecutiveDays && state.lastDayPlayed) {
@@ -92,14 +129,31 @@ function canPlace(
 
 function markPlaced(teamA: string, teamB: string, day: string, availability: Record<string, TeamAvailability>) {
   [teamA, teamB].forEach((team) => {
-    if (!availability[team]) availability[team] = { dayCounts: {} };
+    if (!availability[team]) availability[team] = { dayCounts: {}, totalMatches: 0, venues: {} };
     availability[team].dayCounts[day] = (availability[team].dayCounts[day] || 0) + 1;
     availability[team].lastDayPlayed = day;
+    availability[team].totalMatches += 1;
   });
+}
+
+function matchFairnessScore(teamA: string, teamB: string, day: string, venue: string, availability: Record<string, TeamAvailability>) {
+  const stateA = availability[teamA] || { dayCounts: {}, totalMatches: 0, venues: {} };
+  const stateB = availability[teamB] || { dayCounts: {}, totalMatches: 0, venues: {} };
+  const matchesGapPenalty = Math.abs(stateA.totalMatches - stateB.totalMatches) * 10;
+  const dateDistancePenalty = [stateA.lastDayPlayed, stateB.lastDayPlayed].reduce((acc, lastDay) => {
+    if (!lastDay) return acc;
+    const diffDays = (new Date(`${day}T00:00:00Z`).getTime() - new Date(`${lastDay}T00:00:00Z`).getTime()) / (1000 * 60 * 60 * 24);
+    return acc + (diffDays <= 2 ? (3 - diffDays) * 5 : 0);
+  }, 0);
+  const venueRepeatPenalty = (stateA.venues[venue] || 0) + (stateB.venues[venue] || 0);
+  return matchesGapPenalty + dateDistancePenalty + venueRepeatPenalty;
 }
 
 export function generateTournamentSchedule(input: GeneratorInput): ScheduleMatch[] {
   const { teams, policy } = input;
+  if (!policy.start_date || !policy.end_date || new Date(policy.start_date).getTime() > new Date(policy.end_date).getTime()) {
+    return [];
+  }
   const days = listDays(policy.start_date, policy.end_date);
   const candidateMatches = matchesByFormat(policy.format, teams);
   const availability: Record<string, TeamAvailability> = {};
@@ -114,26 +168,33 @@ export function generateTournamentSchedule(input: GeneratorInput): ScheduleMatch
 
   for (const slot of slots) {
     if (!queue.length) break;
+    const venue = policy.venues[slot.slotIndex % Math.max(1, policy.venues.length)] || 'Main Ground';
 
-    const nextIndex = queue.findIndex(([teamA, teamB]) => canPlace(
-      teamA,
-      teamB,
-      slot.day,
-      availability,
-      policy.allow_same_day_multiple_matches,
-      policy.allow_consecutive_days,
-    ));
+    const selectable = queue
+      .map(([teamA, teamB], index) => ({ teamA, teamB, index }))
+      .filter(({ teamA, teamB }) => canPlace(
+        teamA,
+        teamB,
+        slot.day,
+        availability,
+        policy.allow_same_day_multiple_matches,
+        policy.allow_consecutive_days,
+      ))
+      .map((entry) => ({ ...entry, score: matchFairnessScore(entry.teamA, entry.teamB, slot.day, venue, availability) }))
+      .sort((a, b) => a.score - b.score);
 
-    if (nextIndex < 0) continue;
+    if (!selectable.length) continue;
 
-    const [teamA, teamB] = queue.splice(nextIndex, 1)[0];
+    const [teamA, teamB] = queue.splice(selectable[0].index, 1)[0];
     markPlaced(teamA, teamB, slot.day, availability);
+    availability[teamA].venues[venue] = (availability[teamA].venues[venue] || 0) + 1;
+    availability[teamB].venues[venue] = (availability[teamB].venues[venue] || 0) + 1;
 
     output.push({
       match_id: generateId('SCHM'),
       date: slot.day,
       time: slot.time,
-      venue: policy.venues[slot.slotIndex % Math.max(1, policy.venues.length)] || 'Main Ground',
+      venue,
       team_a: teamA,
       team_b: teamB,
       stage: stageLabelByFormat[policy.format],


### PR DESCRIPTION
### Motivation
- Provide a more professional, fair tournament scheduler that balances rest, venue distribution and supports common formats (round-robin, double-leg, eliminations). 
- Make official, certified schedule releases visible on the public Schedules page even when no PDF is uploaded so visitors can view official fixtures. 
- Preserve existing admin manual-file publish/delete flow while clearly distinguishing uploaded files from governance-released fixtures.

### Description
- Enhanced scheduler logic in `src/schedules/scheduleGenerator.ts` by adding `rotateForRoundRobin`, `roundRobinMatches`, `eliminationMatches`, and a `matchFairnessScore` to prefer fair slot assignments, plus venue distribution tracking and `totalMatches` in `TeamAvailability`. 
- Switched `matchesByFormat` to use the new round-robin and elimination generators and added date-range validation to return an empty schedule for invalid ranges. 
- Updated generation placement to pick the lowest-scoring (fairest) selectable match per slot and record venue usage to avoid repeated venue assignment. 
- Extended `src/pages/SchedulesPage.tsx` to fetch both `PUBLIC_SCHEDULES` and certified `schedules`, introduced a `PublishedMatchSchedule` view type, and merged manual files and governance releases into the public list. 
- Added fixture-table rendering (IST slot, teams, venue, stage) for certified governance releases when no PDF is present, added a source badge (`Season release` vs `Uploaded file`) and kept admin upload/delete behavior (with `removeSchedule` adapted to accept an id). 

### Testing
- Ran `git diff --check` which completed without reported diffs. 
- Attempted `npm run test` (vitest) which failed because test runner binaries were not available in this environment. 
- Attempted `npm run build` (vite) which failed for the same reason. 
- Attempted `npm install` which failed due to registry access policy (`403 Forbidden`) in this environment, so automated test/build steps could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30a3803b4832cae401b6be45bbde7)