### PR TITLE
Allow management users to access scorelists page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,7 +155,7 @@ const App = () => (
                   <Route path="/player" element={<PlayerDashboard />} />
                   <Route path="/admin/match-center" element={<RequireRole allow={['admin']}><MatchCenter /></RequireRole>} />
                   <Route path="/admin/backups" element={<RequireRole allow={['admin']}><AdminBackups /></RequireRole>} />
-                  <Route path="/admin/scorelists" element={<RequireRole allow={['admin']}><AdminScorelistsPage /></RequireRole>} />
+                  <Route path="/admin/scorelists" element={<RequireRole allow={['admin', 'management']}><AdminScorelistsPage /></RequireRole>} />
                   <Route path="/admin/management" element={<RequireRole allow={['admin']}><AdminManagement /></RequireRole>} />
                   <Route path="/admin/work-queue" element={<RequireRole allow={['admin']}><AdminWorkQueuePage /></RequireRole>} />
                   <Route path="/admin/ops-center" element={<RequireRole allow={['admin', 'management']}><AdminOpsCenter /></RequireRole>} />


### PR DESCRIPTION
### Motivation
- Management-role approvers were blocked by the route guard from reaching the scorelist approval dashboard (`/admin/scorelists`), preventing them from reviewing or signing scorelists.

### Description
- Updated the route guard in `src/App.tsx` to allow both `admin` and `management` roles for the `/admin/scorelists` route by changing the `RequireRole` `allow` list to `['admin', 'management']`.

### Testing
- Attempted to run a local build with `npm run -s build`, which failed in this environment because the Vite binary is unavailable (`vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3789caa9c832cbd7f918e5e0ae57e)